### PR TITLE
fix(react-ui): don't submit on Enter while an IME composition is open

### DIFF
--- a/packages/react-ui/src/components/AgentInterface/__tests__/composerKeyboard.test.ts
+++ b/packages/react-ui/src/components/AgentInterface/__tests__/composerKeyboard.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { ComposerKeyDownEvent, shouldSubmitOnEnter } from "../_shared/utils/composerKeyboard";
+
+const keyDown = (overrides: Partial<ComposerKeyDownEvent> = {}): ComposerKeyDownEvent => ({
+  key: "Enter",
+  shiftKey: false,
+  keyCode: 13,
+  nativeEvent: { isComposing: false },
+  ...overrides,
+});
+
+describe("shouldSubmitOnEnter", () => {
+  it("submits on a plain Enter", () => {
+    expect(shouldSubmitOnEnter(keyDown())).toBe(true);
+  });
+
+  it("does not submit on Shift+Enter — that inserts a newline", () => {
+    expect(shouldSubmitOnEnter(keyDown({ shiftKey: true }))).toBe(false);
+  });
+
+  it("ignores keys other than Enter", () => {
+    expect(shouldSubmitOnEnter(keyDown({ key: "a", keyCode: 65 }))).toBe(false);
+  });
+
+  it("does not submit while an IME composition is open (isComposing)", () => {
+    expect(shouldSubmitOnEnter(keyDown({ nativeEvent: { isComposing: true } }))).toBe(false);
+  });
+
+  it("does not submit when the browser reports the IME sentinel keyCode 229", () => {
+    // Safari and older Chromium leave isComposing unset on this keydown.
+    expect(shouldSubmitOnEnter(keyDown({ keyCode: 229 }))).toBe(false);
+  });
+
+  it("submits on the Enter that follows a finished composition", () => {
+    expect(shouldSubmitOnEnter(keyDown({ nativeEvent: { isComposing: false } }))).toBe(true);
+  });
+});

--- a/packages/react-ui/src/components/AgentInterface/_shared/utils/composerKeyboard.ts
+++ b/packages/react-ui/src/components/AgentInterface/_shared/utils/composerKeyboard.ts
@@ -1,0 +1,40 @@
+/**
+ * The subset of a `keydown` event the composers need to decide whether `Enter`
+ * submits. React's `KeyboardEvent<HTMLTextAreaElement>` satisfies it
+ * structurally, so call sites pass the synthetic event straight through and
+ * tests can build a plain object.
+ */
+export interface ComposerKeyDownEvent {
+  key: string;
+  shiftKey: boolean;
+  keyCode: number;
+  nativeEvent: { isComposing: boolean };
+}
+
+/**
+ * Safari and older Chromium report `keyCode` 229 for a keydown consumed by an
+ * open IME composition, and do not always have `isComposing` set on that same
+ * event. Checking both covers each browser's timing.
+ */
+const IME_KEY_CODE = 229;
+
+/**
+ * Whether an `Enter` keydown in a composer textarea should send the draft.
+ *
+ * `Enter` sends and `Shift+Enter` inserts a newline — except while an IME
+ * composition is open, where `Enter` belongs to the IME (it commits the
+ * conversion candidate) and must not reach the composer.
+ *
+ * Without this guard, Windows Voice Typing holds a composition session open
+ * across dictation: a physical `Enter` sends and clears the textarea, the
+ * composition then finalizes and fires one more `onChange`, and the dictated
+ * text reappears in the box the user just emptied. Every CJK IME hits the same
+ * path and sends a half-converted phrase instead of committing it.
+ *
+ * Consequence, shared with every IME-aware composer: the `Enter` that closes a
+ * composition does not send. The next one does.
+ */
+export const shouldSubmitOnEnter = (event: ComposerKeyDownEvent): boolean => {
+  if (event.key !== "Enter" || event.shiftKey) return false;
+  return !event.nativeEvent.isComposing && event.keyCode !== IME_KEY_CODE;
+};

--- a/packages/react-ui/src/components/AgentInterface/components/Composer.tsx
+++ b/packages/react-ui/src/components/AgentInterface/components/Composer.tsx
@@ -6,6 +6,7 @@ import { useLayoutContext } from "../../../context/LayoutContext";
 import { useAutoFocus } from "../../../hooks/useAutoFocus";
 import { useComposerState } from "../../../hooks/useComposerState";
 import { IconButton } from "../../IconButton";
+import { shouldSubmitOnEnter } from "../_shared/utils/composerKeyboard";
 
 export interface ComposerProps {
   className?: string;
@@ -87,7 +88,7 @@ export const Composer = ({ className, placeholder = "Type your query here" }: Co
           placeholder={placeholder}
           rows={1}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
+            if (shouldSubmitOnEnter(e)) {
               e.preventDefault();
               handleSubmit();
             }

--- a/packages/react-ui/src/components/AgentInterface/components/DesktopWelcomeComposer.tsx
+++ b/packages/react-ui/src/components/AgentInterface/components/DesktopWelcomeComposer.tsx
@@ -6,6 +6,7 @@ import { useLayoutContext } from "../../../context/LayoutContext";
 import { useAutoFocus } from "../../../hooks/useAutoFocus";
 import { useComposerState } from "../../../hooks/useComposerState";
 import { IconButton } from "../../IconButton";
+import { shouldSubmitOnEnter } from "../_shared/utils/composerKeyboard";
 
 export interface DesktopWelcomeComposerProps {
   className?: string;
@@ -88,7 +89,7 @@ export const DesktopWelcomeComposer = ({
         placeholder={placeholder}
         rows={1}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && !e.shiftKey) {
+          if (shouldSubmitOnEnter(e)) {
             e.preventDefault();
             handleSubmit();
           }


### PR DESCRIPTION
## What

Fixes #1045.

Both built-in composers in `@openuidev/react-ui` submit on **any** `Enter` keydown, with no awareness of IME composition state — there is currently no composition guard anywhere in the package (`grep -rn "isComposing" packages/react-ui/src` returns nothing).

Windows Voice Typing holds an IME composition session open across dictation. A physical `Enter` therefore submits and clears the textarea, the still-open composition finalizes a moment later and fires one more `onChange`, and the dictated text reappears in the box the user just emptied. That is the race in the issue.

The blast radius is wider than the report suggests: **every IME-based input hits the same path**. For Japanese, Chinese and Korean input, `Enter` is the key that *confirms* a conversion candidate — today that keypress sends a half-converted phrase instead of committing it.

The issue reporter worked around this in their own app via `AgentInterface.Composer`'s Mode C, patching one composer. This fixes it in the library, for both.

## Changes

- Add `shouldSubmitOnEnter()` in `AgentInterface/_shared/utils/composerKeyboard.ts` — a pure predicate that returns `false` while a composition is open.
  - Checks `nativeEvent.isComposing`, **plus** the `keyCode === 229` sentinel, since Safari and older Chromium dispatch the composition-consumed `keydown` before `isComposing` is set.
  - Takes a narrow structural `ComposerKeyDownEvent` that React's `KeyboardEvent<HTMLTextAreaElement>` satisfies, so call sites pass the synthetic event straight through and tests build a plain object — no casts, no DOM.
- Route both composers through it, so the condition has one source of truth instead of two copies:
  - `AgentInterface/components/Composer.tsx`
  - `AgentInterface/components/DesktopWelcomeComposer.tsx`
- Add `__tests__/composerKeyboard.test.ts` covering plain `Enter`, `Shift+Enter`, non-`Enter` keys, `isComposing`, the `229` sentinel, and the `Enter` that follows a finished composition.

### Behavior change

While a composition is open, `Enter` no longer sends — it closes the composition, and the next `Enter` sends. This is standard IME behavior, matches what `assistant-ui`'s own composer does, and is precisely what removes the race. Non-IME typing is unaffected: `Enter` sends, `Shift+Enter` inserts a newline, exactly as before.

### On the approach

I went with a shared pure helper rather than a `compositionstart`/`compositionend` ref inside each component for two reasons: it keeps the two composers from drifting apart again, and it stays testable under the package's existing setup. `react-ui` has no jsdom today — every test here is SSR or pure — so a component-level interaction test would mean adding a DOM environment, a larger diff than the fix itself. Happy to inline the guard in both components instead if you'd prefer that.

## Test Plan

- [x] Verified locally

```
pnpm --filter @openuidev/react-ui run ci
```

- `lint:check` — 0 errors (27 pre-existing `react-hooks/exhaustive-deps` warnings in `genui-lib`/`hooks`, none from these files)
- `format:check` — clean
- `test` — **40 passed across 8 files** (6 new)

`pnpm --filter @openuidev/react-ui typecheck` reports 73 errors, but the count is byte-identical on a clean checkout of `main` — all in `genui-lib`, none in `AgentInterface`. It is also not part of the package's `ci` script, so I left it alone rather than widening this PR.

## Checklist

- [x] I linked a related issue, if applicable
- [x] I updated docs/README when needed — no public API change; the helper is internal to `AgentInterface`
- [x] I considered backwards compatibility — no exported surface changes; the only behavioral difference is the IME case described above
