### PR TITLE
cli: quiet installs, spinner, and thesys next.config workaround

### DIFF
--- a/packages/openui-cli/src/auth/mint.ts
+++ b/packages/openui-cli/src/auth/mint.ts
@@ -185,7 +185,7 @@ export async function resolveCloudApiKey(opts: {
 
   if (method === "manual") {
     console.warn(
-      "⚠ --auth manual is deprecated. Use browser sign-in or pass --api-key for scripted setup.",
+      "[!] --auth manual is deprecated. Use browser sign-in or pass --api-key for scripted setup.",
     );
     const { password } = await import("@inquirer/prompts");
     const key = await cloudAuthPrompt("manual_key_prompt", "MANUAL_KEY_PROMPT_FAILED", () =>

--- a/packages/openui-cli/src/commands/create-app.ts
+++ b/packages/openui-cli/src/commands/create-app.ts
@@ -279,10 +279,7 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
     restoreDotfiles(targetDir);
     applyOverlay(targetDir, overlay);
     rewritePackageJson(targetDir, name, packageManager.name, overlay?.manifest.packageJson);
-    // npm ci needs package-lock.json. Keep it for npm scaffolds of the base
-    // template, or a backend overlay that ships its own. An overlay that
-    // changes dependencies without a lock must not keep the base lock — npm
-    // install resolves the new ranges instead. Other managers always drop it.
+    // An overlay that changes dependencies without a lock must not keep the base lock
     const overlayShipsNpmLock = Boolean(
       overlay && fs.existsSync(path.join(overlay.dir, "package-lock.json")),
     );

--- a/packages/openui-cli/src/commands/create-app.ts
+++ b/packages/openui-cli/src/commands/create-app.ts
@@ -3,7 +3,7 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { resolveCloudApiKey, THESYS_KEYS_URL } from "../auth/mint";
-import { dumpFailureLog, QUIET_COMMAND_CAPTURE_LIMIT } from "../lib/command-output";
+import { printLogTail, QUIET_COMMAND_CAPTURE_LIMIT } from "../lib/command-output";
 import { aiSetupFromTemplate, createFunnelProps } from "../lib/create-telemetry";
 import type { CreateAppOptions, EnvResult, OverlayName, TemplateName } from "../lib/create-types";
 import {
@@ -456,7 +456,7 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
       });
     } else {
       if (!options.verbose) {
-        dumpFailureLog(installResult.diagnosticTail, "install log (tail)");
+        printLogTail(installResult.diagnosticTail, "install log (tail)");
       }
       const properties = processErrorProperties(installResult, "dependency_install", {
         error_class: "dependency",

--- a/packages/openui-cli/src/commands/create-app.ts
+++ b/packages/openui-cli/src/commands/create-app.ts
@@ -279,9 +279,14 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
     restoreDotfiles(targetDir);
     applyOverlay(targetDir, overlay);
     rewritePackageJson(targetDir, name, packageManager.name, overlay?.manifest.packageJson);
-    // npm ci needs package-lock.json. Keep it for npm scaffolds (base template or
-    // a backend overlay that ships its own). Other managers resolve from package.json.
-    if (packageManager.name !== "npm") {
+    // npm ci needs package-lock.json. Keep it for npm scaffolds of the base
+    // template, or a backend overlay that ships its own. An overlay that
+    // changes dependencies without a lock must not keep the base lock — npm
+    // install resolves the new ranges instead. Other managers always drop it.
+    const overlayShipsNpmLock = Boolean(
+      overlay && fs.existsSync(path.join(overlay.dir, "package-lock.json")),
+    );
+    if (packageManager.name !== "npm" || (overlay && !overlayShipsNpmLock)) {
       fs.rmSync(path.join(targetDir, "package-lock.json"), { force: true });
     }
     // The Cloud template ships pnpm's lock/workspace files for reproducible pnpm

--- a/packages/openui-cli/src/commands/create-app.ts
+++ b/packages/openui-cli/src/commands/create-app.ts
@@ -423,21 +423,31 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
       template,
       ai_setup: aiSetup,
     });
-    const installResult = await withSpinner("Installing dependencies...", () =>
-      runCommand(packageManager.runCmd, installArgs, targetDir, {
-        echo: false,
-        stdin: "ignore",
-        captureLimit: QUIET_COMMAND_CAPTURE_LIMIT,
-        env: {
-          ...process.env,
-          npm_config_loglevel: "error",
-          NPM_CONFIG_LOGLEVEL: "error",
-        },
-      }),
-    );
+    const runInstall = () =>
+      options.verbose
+        ? runCommand(packageManager.runCmd, installArgs, targetDir)
+        : runCommand(packageManager.runCmd, installArgs, targetDir, {
+            echo: false,
+            stdin: "ignore",
+            captureLimit: QUIET_COMMAND_CAPTURE_LIMIT,
+            env: {
+              ...process.env,
+              npm_config_loglevel: "error",
+              NPM_CONFIG_LOGLEVEL: "error",
+            },
+          });
+
+    if (options.verbose) {
+      console.info(`Installing dependencies with: ${installCmd}\n`);
+    }
+    const installResult = options.verbose
+      ? await runInstall()
+      : await withSpinner("Installing dependencies...", runInstall);
     if (!installResult.error && installResult.status === 0) {
       dependencyInstalled = true;
-      console.info("✓ Dependencies installed\n");
+      if (!options.verbose) {
+        console.info("✓ Dependencies installed\n");
+      }
       telemetry.capture("cli_dependency_install_succeeded", {
         ...createFunnelProps("dependency_install_succeeded"),
         template,
@@ -445,7 +455,9 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
         dependency_installed: dependencyInstalled,
       });
     } else {
-      dumpFailureLog(installResult.diagnosticTail, "install log (tail)");
+      if (!options.verbose) {
+        dumpFailureLog(installResult.diagnosticTail, "install log (tail)");
+      }
       const properties = processErrorProperties(installResult, "dependency_install", {
         error_class: "dependency",
         error_code: "NONZERO_EXIT",

--- a/packages/openui-cli/src/commands/create-app.ts
+++ b/packages/openui-cli/src/commands/create-app.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { resolveCloudApiKey, THESYS_KEYS_URL } from "../auth/mint";
 import { aiSetupFromTemplate, createFunnelProps } from "../lib/create-telemetry";
 import type { CreateAppOptions, EnvResult, OverlayName, TemplateName } from "../lib/create-types";
+import { dumpFailureLog, QUIET_COMMAND_CAPTURE_LIMIT } from "../lib/command-output";
 import {
   resolveInstallPackageManager,
   type PackageManagerName,
@@ -14,6 +15,7 @@ import { runSkillInstall, shouldInstallSkill } from "../lib/install-skill";
 import { applyOverlay, OVERLAYS_DIR, resolveOverlay, type OverlayManifest } from "../lib/overlays";
 import { runCommand } from "../lib/process-runner";
 import { resolveArgs } from "../lib/resolve-args";
+import { withSpinner } from "../lib/spinner";
 import { resolveAvailableTarget } from "../lib/target-dir";
 import { CliCancelledError, CreateError, telemetry } from "../lib/telemetry";
 import { cliErrorProperties, processErrorProperties } from "../lib/utils";
@@ -416,15 +418,26 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
     });
     console.info(`Skipping dependency install (--no-install). Run \`${installCmd}\` later.\n`);
   } else {
-    console.info(`Installing dependencies with: ${installCmd}\n`);
     telemetry.capture("cli_dependency_install_started", {
       ...createFunnelProps("dependency_install_started"),
       template,
       ai_setup: aiSetup,
     });
-    const installResult = await runCommand(packageManager.runCmd, installArgs, targetDir);
+    const installResult = await withSpinner("Installing dependencies...", () =>
+      runCommand(packageManager.runCmd, installArgs, targetDir, {
+        echo: false,
+        stdin: "ignore",
+        captureLimit: QUIET_COMMAND_CAPTURE_LIMIT,
+        env: {
+          ...process.env,
+          npm_config_loglevel: "error",
+          NPM_CONFIG_LOGLEVEL: "error",
+        },
+      }),
+    );
     if (!installResult.error && installResult.status === 0) {
       dependencyInstalled = true;
+      console.info("✓ Dependencies installed\n");
       telemetry.capture("cli_dependency_install_succeeded", {
         ...createFunnelProps("dependency_install_succeeded"),
         template,
@@ -432,6 +445,7 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
         dependency_installed: dependencyInstalled,
       });
     } else {
+      dumpFailureLog(installResult.diagnosticTail, "install log (tail)");
       const properties = processErrorProperties(installResult, "dependency_install", {
         error_class: "dependency",
         error_code: "NONZERO_EXIT",
@@ -490,7 +504,6 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
       skillInstalled,
       envWritten: envResult.envWritten,
       startDev,
-      devStartBlockedByMissingApiKey,
       installCmd,
       dependencyInstalled,
     }),
@@ -501,15 +514,6 @@ export async function runCreateApp(options: CreateAppOptions): Promise<void> {
       skip_reason: "missing_api_key",
       required_env: apiKeyEnv,
     });
-    const keyHint =
-      apiKeyEnv === "THESYS_API_KEY"
-        ? `Get a key at ${THESYS_KEYS_URL}, then add:\n\n  ${apiKeyEnv}=…\n\nto ${name}/.env`
-        : `Add your key to ${name}/.env:\n\n  ${apiKeyEnv}=…`;
-    console.error(
-      `\nSkipped starting the development server — ${apiKeyEnv} is missing.\n\n` +
-        `${keyHint}\n\n` +
-        `Then run:\n\n> cd ${name}\n> ${devCmd} run dev\n`,
-    );
     process.exitCode = 1;
     return;
   }
@@ -687,7 +691,7 @@ async function resolveCloudEnv(
       auth_succeeded: false,
       ...properties,
     });
-    console.error(`\n⚠ Could not obtain an API key: ${msg}`);
+    console.error(`\n[!] Could not obtain an API key: ${msg}`);
     console.error(`  Add THESYS_API_KEY to .env later (keys: ${THESYS_KEYS_URL}).\n`);
   }
   const lines = [`THESYS_API_KEY=${apiKey ?? ""}`, `DEMO_USER_ID=demo-user`];
@@ -707,7 +711,6 @@ function getStartedMessage(o: {
   skillInstalled: boolean;
   envWritten: boolean;
   startDev: boolean;
-  devStartBlockedByMissingApiKey: boolean;
   installCmd: string;
   dependencyInstalled: boolean;
 }): string {
@@ -719,20 +722,18 @@ function getStartedMessage(o: {
     o.template === "openui-cloud"
       ? o.envWritten
         ? "✅ .env created with your OpenUI Cloud API key + base URL."
-        : `⚠ .env created without a key. Add THESYS_API_KEY=… (get one at ${THESYS_KEYS_URL}).`
+        : `[!] .env created without a key. Add THESYS_API_KEY=… (get one at ${THESYS_KEYS_URL}).`
       : o.envWritten
         ? "✅ .env created with your API key."
         : "Add your API key to .env:\nOPENAI_API_KEY=sk-your-key-here";
 
   const nextStep = o.startDev
     ? `Starting the development server in "${o.name}"...\n\n> ${o.devCmd} run dev`
-    : o.devStartBlockedByMissingApiKey
-      ? ""
-      : [
-          `> cd ${o.name}`,
-          ...(o.dependencyInstalled ? [] : [`> ${o.installCmd}`]),
-          `> ${o.devCmd} run dev`,
-        ].join("\n");
+    : [
+        `> cd ${o.name}`,
+        ...(o.dependencyInstalled ? [] : [`> ${o.installCmd}`]),
+        `> ${o.devCmd} run dev`,
+      ].join("\n");
 
   const frameworkNote = o.backendGettingStarted?.replaceAll("{{packageManager}}", o.devCmd) ?? "";
 

--- a/packages/openui-cli/src/commands/create-app.ts
+++ b/packages/openui-cli/src/commands/create-app.ts
@@ -3,9 +3,9 @@ import * as os from "node:os";
 import * as path from "node:path";
 
 import { resolveCloudApiKey, THESYS_KEYS_URL } from "../auth/mint";
+import { dumpFailureLog, QUIET_COMMAND_CAPTURE_LIMIT } from "../lib/command-output";
 import { aiSetupFromTemplate, createFunnelProps } from "../lib/create-telemetry";
 import type { CreateAppOptions, EnvResult, OverlayName, TemplateName } from "../lib/create-types";
-import { dumpFailureLog, QUIET_COMMAND_CAPTURE_LIMIT } from "../lib/command-output";
 import {
   resolveInstallPackageManager,
   type PackageManagerName,

--- a/packages/openui-cli/src/index.ts
+++ b/packages/openui-cli/src/index.ts
@@ -72,6 +72,7 @@ program
   .option("--no-install", "Scaffold without running the package install")
   .option("-i, --immediate", "Start the development server after installing dependencies")
   .option("--no-immediate", "Install dependencies without starting the development server")
+  .option("--verbose", "Stream full dependency install logs")
   .addHelpText(
     "after",
     `
@@ -103,6 +104,7 @@ Backend frameworks:
       interactive: boolean;
       install: boolean;
       immediate?: boolean;
+      verbose?: boolean;
     }) => {
       try {
         rejectConflictingImmediateFlags(process.argv.slice(2));
@@ -116,6 +118,7 @@ Backend frameworks:
           noInteractive: !options.interactive,
           noInstall: !options.install,
           immediate: options.immediate,
+          verbose: options.verbose,
         });
       } catch (e) {
         handleCliError(e, "cli_create_failed");

--- a/packages/openui-cli/src/lib/command-output.ts
+++ b/packages/openui-cli/src/lib/command-output.ts
@@ -1,0 +1,10 @@
+/** Enough build/install output to dump a useful failure tail in quiet mode. */
+export const QUIET_COMMAND_CAPTURE_LIMIT = 256 * 1024;
+
+export function dumpFailureLog(log: string, title = "build log (tail)"): void {
+  const trimmed = log.trim();
+  if (!trimmed) return;
+  console.error(`\n--- ${title} ---\n`);
+  process.stderr.write(trimmed + "\n");
+  console.error("---\n");
+}

--- a/packages/openui-cli/src/lib/command-output.ts
+++ b/packages/openui-cli/src/lib/command-output.ts
@@ -1,7 +1,7 @@
 /** Enough build/install output to dump a useful failure tail in quiet mode. */
 export const QUIET_COMMAND_CAPTURE_LIMIT = 256 * 1024;
 
-export function dumpFailureLog(log: string, title = "build log (tail)"): void {
+export function printLogTail(log: string, title = "build log (tail)"): void {
   const trimmed = log.trim();
   if (!trimmed) return;
   console.error(`\n--- ${title} ---\n`);

--- a/packages/openui-cli/src/lib/create-types.ts
+++ b/packages/openui-cli/src/lib/create-types.ts
@@ -12,7 +12,6 @@ export interface CreateAppOptions {
   noInteractive?: boolean;
   noInstall?: boolean;
   immediate?: boolean;
-  /** Stream full dependency install logs instead of quiet spinner output. */
   verbose?: boolean;
   apiKey?: string;
   auth?: CloudAuthMethod;

--- a/packages/openui-cli/src/lib/create-types.ts
+++ b/packages/openui-cli/src/lib/create-types.ts
@@ -12,6 +12,8 @@ export interface CreateAppOptions {
   noInteractive?: boolean;
   noInstall?: boolean;
   immediate?: boolean;
+  /** Stream full dependency install logs instead of quiet spinner output. */
+  verbose?: boolean;
   apiKey?: string;
   auth?: CloudAuthMethod;
 }

--- a/packages/openui-cli/src/lib/overlays.ts
+++ b/packages/openui-cli/src/lib/overlays.ts
@@ -55,6 +55,18 @@ export function resolveOverlay(
   };
 }
 
+function removeEmptyParentDirs(projectDir: string, removedRelativePath: string) {
+  let dir = path.dirname(path.join(projectDir, removedRelativePath));
+
+  while (true) {
+    const relative = path.relative(projectDir, dir);
+    if (!relative || relative.startsWith("..")) break;
+    if (fs.readdirSync(dir).length > 0) break;
+    fs.rmdirSync(dir);
+    dir = path.dirname(dir);
+  }
+}
+
 export function applyOverlay(projectDir: string, overlay?: TemplateOverlay) {
   if (!overlay) return;
 
@@ -67,5 +79,6 @@ export function applyOverlay(projectDir: string, overlay?: TemplateOverlay) {
 
   for (const relativePath of overlay.manifest.files?.remove ?? []) {
     fs.rmSync(path.join(projectDir, relativePath), { recursive: true, force: true });
+    removeEmptyParentDirs(projectDir, relativePath);
   }
 }

--- a/packages/openui-cli/src/lib/process-runner.ts
+++ b/packages/openui-cli/src/lib/process-runner.ts
@@ -12,6 +12,14 @@ export type CommandResult = {
 
 export type RunCommandOptions = {
   env?: NodeJS.ProcessEnv;
+  /** When false, capture stdout/stderr without writing them to the parent. Default true. */
+  echo?: boolean;
+  /** Default inherit so interactive CLIs can prompt. Use ignore for login probes. */
+  stdin?: "inherit" | "ignore";
+  /** Inherit stdout/stderr so the child sees a TTY (needed for `vercel login`). */
+  inheritOutput?: boolean;
+  /** Max bytes retained in `diagnosticTail` when output is piped. Default 16KiB. */
+  captureLimit?: number;
 };
 
 /**
@@ -31,10 +39,17 @@ export function runCommand(
 ): Promise<CommandResult> {
   return new Promise((resolve) => {
     const startedAt = Date.now();
+    const echo = options.echo !== false;
+    const inheritOutput = Boolean(options.inheritOutput);
+    const captureLimit = options.captureLimit ?? DIAGNOSTIC_TAIL_LIMIT;
     const child = spawn(command, args, {
       cwd,
       env: options.env,
-      stdio: ["inherit", "pipe", "pipe"],
+      stdio: [
+        options.stdin === "ignore" ? "ignore" : "inherit",
+        inheritOutput ? "inherit" : "pipe",
+        inheritOutput ? "inherit" : "pipe",
+      ],
     });
     let diagnosticTail = "";
     let settled = false;
@@ -42,16 +57,18 @@ export function runCommand(
     let forceKillTimer: NodeJS.Timeout | undefined;
 
     const observe = (chunk: Buffer) => {
-      diagnosticTail = (diagnosticTail + chunk.toString("utf8")).slice(-DIAGNOSTIC_TAIL_LIMIT);
+      diagnosticTail = (diagnosticTail + chunk.toString("utf8")).slice(-captureLimit);
     };
-    child.stdout?.on("data", (chunk: Buffer) => {
-      process.stdout.write(chunk);
-      observe(chunk);
-    });
-    child.stderr?.on("data", (chunk: Buffer) => {
-      process.stderr.write(chunk);
-      observe(chunk);
-    });
+    if (!inheritOutput) {
+      child.stdout?.on("data", (chunk: Buffer) => {
+        if (echo) process.stdout.write(chunk);
+        observe(chunk);
+      });
+      child.stderr?.on("data", (chunk: Buffer) => {
+        if (echo) process.stderr.write(chunk);
+        observe(chunk);
+      });
+    }
 
     const finish = (result: Omit<CommandResult, "diagnosticTail" | "durationMs">) => {
       if (settled) return;

--- a/packages/openui-cli/src/lib/spinner.ts
+++ b/packages/openui-cli/src/lib/spinner.ts
@@ -1,0 +1,39 @@
+import * as readline from "node:readline";
+
+/**
+ * Terminal spinner for long-running work. Safe in non-TTY (prints the label once).
+ * Clears the spinner line before resolving so callers can print a final status.
+ *
+ * Uses readline cursor APIs instead of bare `\r` — some terminals (including
+ * Cursor/VS Code) don't reliably overwrite the current line with carriage return.
+ */
+export async function withSpinner<T>(label: string, run: () => Promise<T>): Promise<T> {
+  if (!process.stdout.isTTY) {
+    console.info(label);
+    return run();
+  }
+
+  const frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+  let frame = 0;
+
+  const render = () => {
+    readline.clearLine(process.stdout, 0);
+    readline.cursorTo(process.stdout, 0);
+    process.stdout.write(`${frames[frame]} ${label}`);
+  };
+
+  render();
+  const timer = setInterval(() => {
+    frame = (frame + 1) % frames.length;
+    render();
+  }, 80);
+  timer.unref();
+
+  try {
+    return await run();
+  } finally {
+    clearInterval(timer);
+    readline.clearLine(process.stdout, 0);
+    readline.cursorTo(process.stdout, 0);
+  }
+}

--- a/packages/openui-cli/src/templates/openui-cloud/next.config.ts
+++ b/packages/openui-cli/src/templates/openui-cloud/next.config.ts
@@ -2,7 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1"],
-  ...(process.env.VERCEL ? {} : { output: "standalone" as const }),
+  output: "standalone",
   turbopack: {
     root: process.cwd(),
   },

--- a/packages/openui-cli/src/templates/openui-cloud/next.config.ts
+++ b/packages/openui-cli/src/templates/openui-cloud/next.config.ts
@@ -2,9 +2,12 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: ["127.0.0.1"],
-  output: "standalone",
+  ...(process.env.VERCEL ? {} : { output: "standalone" as const }),
   turbopack: {
     root: process.cwd(),
+  },
+  experimental: {
+    turbopackMinify: false,
   },
 };
 


### PR DESCRIPTION
## Summary
- Shared spinner + quiet command helpers for long-running CLI steps
- Create flow: quiet dependency install with spinner, clearer `[!]` warnings, less noisy missing-key messaging
- Cloud template: skip turbopack minify so `@openuidev/thesys` SSR survives remangling

## Test plan
- [ ] `pnpm --filter @openuidev/cli run build:cli`
- [ ] `openui create` installs deps with spinner and prints `✓ Dependencies installed`
- [ ] Failed install dumps install log tail
- [ ] Scaffolded cloud app has `experimental.turbopackMinify: false` in `next.config.ts`