### PR TITLE
Add a cloud flag to generateSystemPrompt in lang-core

### DIFF
--- a/docs/app/api/openui-cloud/chat/route.ts
+++ b/docs/app/api/openui-cloud/chat/route.ts
@@ -2,7 +2,8 @@ import { readOpenuiCloudConfig } from "@/lib/openui-cloud/config";
 import { unavailableResponse } from "@/lib/openui-cloud/errors";
 import { resolveRequestedModel } from "@/lib/openui-cloud/models";
 import { hasAllowedOrigin, hasJsonContentType, readLimitedJson } from "@/lib/openui-cloud/request";
-import { artifactTool, generateSystemPrompt } from "@openuidev/thesys-server";
+import { generateSystemPrompt } from "@openuidev/lang-core";
+import { artifactTool } from "@openuidev/thesys-server";
 import OpenAI from "openai";
 import type { ResponseInputItem } from "openai/resources/responses/responses";
 
@@ -56,6 +57,7 @@ export async function POST(request: Request): Promise<Response> {
         { type: "image_search" },
       ],
       instructions: generateSystemPrompt({
+        cloud: true,
         instructions:
           "When creating an artifact, actively use the available web and image search tools to ground its content and visual choices.",
       }),

--- a/docs/content/docs/openui-cloud/api/chat-completions.mdx
+++ b/docs/content/docs/openui-cloud/api/chat-completions.mdx
@@ -14,12 +14,12 @@ Use the `embedClient` from the [API overview](/docs/openui-cloud/api/overview), 
 Use the server helper to have OpenUI Cloud assemble the system prompt for its built-in component library.
 
 ```ts title="server.ts"
-import { generateSystemPrompt } from "@openuidev/thesys-server";
+import { generateSystemPrompt } from "@openuidev/lang-core";
 
 const completion = await embedClient.chat.completions.create({
   model: "openai/gpt-5",
   messages: [
-    { role: "system", content: generateSystemPrompt() },
+    { role: "system", content: generateSystemPrompt({ cloud: true }) },
     { role: "user", content: "Compare quarterly revenue by region." },
   ],
 });
@@ -75,7 +75,7 @@ Hosted `web_search`, `image_search`, remote MCP, and artifacts-as-tool are avail
 
 ### Plain text passthrough
 
-Use a `{provider}/{model}` model ID without the managed `generateSystemPrompt()` sentinel. OpenUI Cloud forwards your messages and system prompt without injecting a generative UI prompt or component schema.
+Use a `{provider}/{model}` model ID without the managed `generateSystemPrompt({ cloud: true })` sentinel. OpenUI Cloud forwards your messages and system prompt without injecting a generative UI prompt or component schema.
 
 ```ts
 const completion = await embedClient.chat.completions.create({

--- a/docs/content/docs/openui-cloud/api/chat-completions.mdx
+++ b/docs/content/docs/openui-cloud/api/chat-completions.mdx
@@ -27,7 +27,7 @@ const completion = await embedClient.chat.completions.create({
 console.log(completion.choices[0].message.content);
 ```
 
-The returned message content is an OpenUI Lang program. See [Component Library](/docs/openui-cloud/build/component-library) for the built-in client library and custom component workflow.
+The returned message content is an OpenUI Lang program. See [Component Library](/docs/openui-cloud/build/component-library) for the built-in client library and using your own library.
 
 ## Stream and render responses
 

--- a/docs/content/docs/openui-cloud/api/conversations.mdx
+++ b/docs/content/docs/openui-cloud/api/conversations.mdx
@@ -27,13 +27,13 @@ const conversation = await conversationClient.conversations.create({
 Then send only the new turn to Responses and set `store: true`:
 
 ```ts
-import { generateSystemPrompt } from "@openuidev/thesys-server";
+import { generateSystemPrompt } from "@openuidev/lang-core";
 
 const response = await embedClient.responses.create({
   model: "openai/gpt-5",
   conversation: conversation.id,
   input: "Compare quarterly revenue by region.",
-  instructions: generateSystemPrompt(),
+  instructions: generateSystemPrompt({ cloud: true }),
   store: true,
   stream: true,
 });

--- a/docs/content/docs/openui-cloud/api/responses.mdx
+++ b/docs/content/docs/openui-cloud/api/responses.mdx
@@ -14,12 +14,12 @@ Use the `embedClient` from the [API overview](/docs/openui-cloud/api/overview), 
 Use the server helper to have OpenUI Cloud assemble the system prompt for its built-in component library.
 
 ```ts title="server.ts"
-import { generateSystemPrompt } from "@openuidev/thesys-server";
+import { generateSystemPrompt } from "@openuidev/lang-core";
 
 const response = await embedClient.responses.create({
   model: "openai/gpt-5",
   input: "Compare quarterly revenue by region.",
-  instructions: generateSystemPrompt(),
+  instructions: generateSystemPrompt({ cloud: true }),
 });
 
 console.log(response.output_text);
@@ -72,14 +72,14 @@ Chain a follow-up to an earlier response:
 const first = await embedClient.responses.create({
   model: "openai/gpt-5",
   input: "Compare quarterly revenue by region.",
-  instructions: generateSystemPrompt(),
+  instructions: generateSystemPrompt({ cloud: true }),
   store: true,
 });
 
 const followUp = await embedClient.responses.create({
   model: "openai/gpt-5",
   input: "Focus on Europe and explain the change.",
-  instructions: generateSystemPrompt(),
+  instructions: generateSystemPrompt({ cloud: true }),
   previous_response_id: first.id,
   store: true,
 });
@@ -105,7 +105,7 @@ import type { Tool } from "openai/resources/responses/responses";
 const response = await embedClient.responses.create({
   model: "openai/gpt-5",
   input: "Research the market and summarize the most important changes.",
-  instructions: generateSystemPrompt(),
+  instructions: generateSystemPrompt({ cloud: true }),
   tools: [
     { type: "web_search" },
     { type: "image_search" } as unknown as Tool,
@@ -129,14 +129,15 @@ For a `function` tool, execute each returned `function_call` on your server and 
 Add `artifactTool()` to generate editable slides or reports inside the agent stream:
 
 ```ts
-import { artifactTool, generateSystemPrompt } from "@openuidev/thesys-server";
+import { generateSystemPrompt } from "@openuidev/lang-core";
+import { artifactTool } from "@openuidev/thesys-server";
 import type { Tool } from "openai/resources/responses/responses";
 
 const response = await embedClient.responses.create({
   model: "openai/gpt-5",
   conversation: threadId,
   input: "Create a three-slide deck on Q4 results.",
-  instructions: generateSystemPrompt(),
+  instructions: generateSystemPrompt({ cloud: true }),
   tools: [artifactTool({ artifacts: ["slides", "report"] }) as unknown as Tool],
   store: true,
   stream: true,

--- a/docs/content/docs/openui-cloud/api/responses.mdx
+++ b/docs/content/docs/openui-cloud/api/responses.mdx
@@ -25,7 +25,7 @@ const response = await embedClient.responses.create({
 console.log(response.output_text);
 ```
 
-The returned `output_text` is an OpenUI Lang program. See [Component Library](/docs/openui-cloud/build/component-library) for the built-in client library and custom component workflow.
+The returned `output_text` is an OpenUI Lang program. See [Component Library](/docs/openui-cloud/build/component-library) for the built-in client library and using your own library.
 
 ## Stream and render responses
 

--- a/docs/content/docs/openui-cloud/build/component-library.mdx
+++ b/docs/content/docs/openui-cloud/build/component-library.mdx
@@ -15,18 +15,19 @@ import { chatLibrary } from "@openuidev/thesys";
 <AgentInterface llm={llm} componentLibrary={chatLibrary} />;
 ```
 
-On the backend, `generateSystemPrompt()` uses the built-in library by default. Use the `embedClient` from the [API overview](/docs/openui-cloud/api/overview); the placement of the generated instructions depends on the API:
+On the backend, `generateSystemPrompt({ cloud: true })` uses the built-in library by default. Use the `embedClient` from the [API overview](/docs/openui-cloud/api/overview); the placement of the generated instructions depends on the API:
 
 <Tabs groupId="cloud-api" items={["Responses", "Chat Completions"]} persist>
   <Tab value="Responses">
 
 ```ts
-import { generateSystemPrompt } from "@openuidev/thesys-server";
+import { generateSystemPrompt } from "@openuidev/lang-core";
 
 const response = await embedClient.responses.create({
   model: "openai/gpt-5",
   input: "Show revenue by region as an interactive dashboard.",
   instructions: generateSystemPrompt({
+    cloud: true,
     instructions: "Optional instructions for the model.",
   }),
 });
@@ -36,7 +37,7 @@ const response = await embedClient.responses.create({
   <Tab value="Chat Completions">
 
 ```ts
-import { generateSystemPrompt } from "@openuidev/thesys-server";
+import { generateSystemPrompt } from "@openuidev/lang-core";
 
 const completion = await embedClient.chat.completions.create({
   model: "openai/gpt-5",
@@ -44,6 +45,7 @@ const completion = await embedClient.chat.completions.create({
     {
       role: "system",
       content: generateSystemPrompt({
+        cloud: true,
         instructions: "Optional instructions for the model.",
       }),
     },
@@ -123,6 +125,7 @@ npx @openuidev/cli@latest generate --spec src/lib/chat-library.tsx --out ./gener
     model: "openai/gpt-5",
     input,
     instructions: generateSystemPrompt({
+      cloud: true,
       instructions: "Optional instructions for the model.",
 +     library: librarySpec,
 +     promptOptions: { preamble: "You build dashboards for Acme operators." },
@@ -142,6 +145,7 @@ npx @openuidev/cli@latest generate --spec src/lib/chat-library.tsx --out ./gener
       {
         role: "system",
         content: generateSystemPrompt({
+          cloud: true,
           instructions: "Optional instructions for the model.",
 +         library: librarySpec,
 +         promptOptions: { preamble: "You build dashboards for Acme operators." },

--- a/docs/content/docs/openui-lang/examples/agent-frameworks/vercel-ai-sdk.mdx
+++ b/docs/content/docs/openui-lang/examples/agent-frameworks/vercel-ai-sdk.mdx
@@ -22,7 +22,7 @@ This example uses the [Vercel AI SDK](https://ai-sdk.dev/) (`streamText`, `tool(
 
 ## How it connects
 
-The API route calls `streamText` with Cloud Completions, `generateSystemPrompt()`, and tools defined with `tool()`. When the model calls a tool, the AI SDK executes it server-side and continues — up to 5 steps. The response is a UIMessage stream.
+The API route calls `streamText` with Cloud Completions, `generateSystemPrompt({ cloud: true })`, and tools defined with `tool()`. When the model calls a tool, the AI SDK executes it server-side and continues — up to 5 steps. The response is a UIMessage stream.
 
 The page passes that stream to `<AgentInterface />`:
 
@@ -54,7 +54,7 @@ Storage is omitted, so AgentInterface uses its built-in in-memory default (wiped
 
 ```ts
 import { createOpenAI } from "@ai-sdk/openai";
-import { generateSystemPrompt } from "@openuidev/thesys-server";
+import { generateSystemPrompt } from "@openuidev/lang-core";
 import { convertToModelMessages, stepCountIs, streamText } from "ai";
 import { tools } from "@/lib/tools";
 
@@ -67,7 +67,7 @@ export async function POST(req: Request) {
   const { messages } = await req.json();
   const result = streamText({
     model: openai.chat("google/gemini-3.6-flash-free"),
-    system: generateSystemPrompt(),
+    system: generateSystemPrompt({ cloud: true }),
     messages: await convertToModelMessages(messages),
     tools,
     stopWhen: stepCountIs(5),

--- a/docs/content/docs/openui-lang/quickstart.mdx
+++ b/docs/content/docs/openui-lang/quickstart.mdx
@@ -297,8 +297,9 @@ Never claim that a recipe is allergen-safe.
 Update the `instructions` field inside `createParams`:
 
 <CopyableDiff
-  code={`-instructions: generateSystemPrompt(),
+  code={`-instructions: generateSystemPrompt({ cloud: true }),
 +instructions: generateSystemPrompt({
++  cloud: true,
 +  library: recipeLibrarySpec,
 +  instructions: recipeInstructions,
 +}),`}

--- a/docs/content/docs/openui-lang/system-prompts.mdx
+++ b/docs/content/docs/openui-lang/system-prompts.mdx
@@ -87,7 +87,7 @@ const systemPrompt = generateSystemPrompt({
 
 ### OpenUI Cloud
 
-Pass `cloud: true` to emit Cloud's managed config block instead of a local prompt. OpenUI Cloud assembles the real system prompt on the server.
+Pass `cloud: true` to emit Cloud's managed config block instead of a local prompt. OpenUI Cloud assembles the real system prompt on the server. `instructions` is Cloud-only extra prose appended after the config block.
 
 ```ts
 import { generateSystemPrompt } from "@openuidev/lang-core";

--- a/docs/content/docs/openui-lang/system-prompts.mdx
+++ b/docs/content/docs/openui-lang/system-prompts.mdx
@@ -85,6 +85,28 @@ const systemPrompt = generateSystemPrompt({
 | `editMode`   | Incremental editing - LLM outputs only changed statements                     | `false`                       |
 | `inlineMode` | Text + fenced code responses - LLM can answer questions without generating UI | `false`                       |
 
+### OpenUI Cloud
+
+Pass `cloud: true` to emit Cloud's managed config block instead of a local prompt. OpenUI Cloud assembles the real system prompt on the server.
+
+```ts
+import { generateSystemPrompt } from "@openuidev/lang-core";
+
+const instructions = generateSystemPrompt({ cloud: true });
+```
+
+With a custom library, pass the generated spec:
+
+```ts
+const instructions = generateSystemPrompt({
+  cloud: true,
+  library: librarySpec,
+  promptOptions: { preamble: "You build dashboards for Acme." },
+});
+```
+
+See [Component Library](/docs/openui-cloud/build/component-library) for the Cloud workflow.
+
 Built-in functions (`@Count`, `@Filter`, `@Sort`, `@Each`, etc.) are automatically included when either `toolCalls` or `bindings` is enabled. For static UI libraries without data fetching, they are omitted to keep the prompt concise.
 
 ### `library.prompt()` (frontend shorthand)

--- a/docs/content/docs/openui-lang/system-prompts.mdx
+++ b/docs/content/docs/openui-lang/system-prompts.mdx
@@ -71,7 +71,7 @@ const systemPrompt = generateSystemPrompt({
     editMode: true, // Enable incremental editing (LLM outputs patches, not full regen)
     inlineMode: true, // Enable text + code responses (LLM can answer questions without code)
 
-    // Custom instructions
+    // Preamble and extra rules
     preamble: "You build dashboards using openui-lang.",
     additionalRules: ['Use @Reset after form submit, not @Set($var, "")'],
   },
@@ -95,7 +95,7 @@ import { generateSystemPrompt } from "@openuidev/lang-core";
 const instructions = generateSystemPrompt({ cloud: true });
 ```
 
-With a custom library, pass the generated spec:
+With your own library, pass the generated spec:
 
 ```ts
 const instructions = generateSystemPrompt({

--- a/packages/lang-core/README.md
+++ b/packages/lang-core/README.md
@@ -61,16 +61,38 @@ const result2 = sp.set("root = Stack([header])\nheader = CardHeader(\"Hello\")\n
 ### Generate a system prompt
 
 ```ts
-import { generatePrompt, type PromptSpec } from "@openuidev/lang-core";
-import componentSpec from "./generated/component-spec.json";
+import { generateSystemPrompt, type LibrarySpec } from "@openuidev/lang-core";
+import librarySpec from "./generated/library.spec.json";
 
-const prompt = generatePrompt({
-  ...componentSpec,
-  tools: myToolSpecs,
-  toolCalls: true,
-  bindings: true,
-  editMode: true,
-  preamble: "You build dashboards.",
+const prompt = generateSystemPrompt({
+  library: librarySpec as LibrarySpec,
+  promptOptions: {
+    tools: myToolSpecs,
+    toolCalls: true,
+    bindings: true,
+    editMode: true,
+    preamble: "You build dashboards.",
+  },
+});
+```
+
+### OpenUI Cloud
+
+Pass `cloud: true` to emit Cloud's managed config block instead of a local prompt. OpenUI Cloud
+assembles the real system prompt on the server.
+
+```ts
+import { generateSystemPrompt } from "@openuidev/lang-core";
+
+// Built-in Cloud chat library
+const instructions = generateSystemPrompt({ cloud: true });
+
+// Custom library (the `.spec.json` from `openui generate`)
+const custom = generateSystemPrompt({
+  cloud: true,
+  library: librarySpec,
+  promptOptions: { preamble: "You build dashboards for Acme." },
+  instructions: "Be terse.",
 });
 ```
 
@@ -100,6 +122,7 @@ const merged = mergeStatements(original, patch);
 | Export | Description |
 | :--- | :--- |
 | `generatePrompt(spec)` | Generate a system prompt from a `PromptSpec` |
+| `generateSystemPrompt(spec)` | Generate a system prompt from `{ library, promptOptions }`. Pass `{ cloud: true }` for OpenUI Cloud's managed config block. |
 
 **`PromptSpec`** includes component signatures, tool definitions (`ToolSpec[]`), feature flags (`toolCalls`, `bindings`, `editMode`, `inlineMode`), examples, and custom rules.
 

--- a/packages/lang-core/README.md
+++ b/packages/lang-core/README.md
@@ -79,7 +79,8 @@ const prompt = generateSystemPrompt({
 ### OpenUI Cloud
 
 Pass `cloud: true` to emit Cloud's managed config block instead of a local prompt. OpenUI Cloud
-assembles the real system prompt on the server.
+assembles the real system prompt on the server. `instructions` is Cloud-only extra prose
+appended after the config block — self-hosted prompts use `preamble` / `additionalRules` instead.
 
 ```ts
 import { generateSystemPrompt } from "@openuidev/lang-core";

--- a/packages/lang-core/README.md
+++ b/packages/lang-core/README.md
@@ -87,7 +87,7 @@ import { generateSystemPrompt } from "@openuidev/lang-core";
 // Built-in Cloud chat library
 const instructions = generateSystemPrompt({ cloud: true });
 
-// Custom library (the `.spec.json` from `openui generate`)
+// Using your own library (the `.spec.json` from `openui generate`)
 const myLibraryPrompt = generateSystemPrompt({
   cloud: true,
   library: librarySpec,

--- a/packages/lang-core/README.md
+++ b/packages/lang-core/README.md
@@ -79,8 +79,7 @@ const prompt = generateSystemPrompt({
 ### OpenUI Cloud
 
 Pass `cloud: true` to emit Cloud's managed config block instead of a local prompt. OpenUI Cloud
-assembles the real system prompt on the server. `instructions` is Cloud-only extra prose
-appended after the config block — self-hosted prompts use `preamble` / `additionalRules` instead.
+assembles the real system prompt on the server.
 
 ```ts
 import { generateSystemPrompt } from "@openuidev/lang-core";
@@ -89,7 +88,7 @@ import { generateSystemPrompt } from "@openuidev/lang-core";
 const instructions = generateSystemPrompt({ cloud: true });
 
 // Custom library (the `.spec.json` from `openui generate`)
-const custom = generateSystemPrompt({
+const myLibraryPrompt = generateSystemPrompt({
   cloud: true,
   library: librarySpec,
   promptOptions: { preamble: "You build dashboards for Acme." },
@@ -122,8 +121,8 @@ const merged = mergeStatements(original, patch);
 
 | Export | Description |
 | :--- | :--- |
-| `generatePrompt(spec)` | Generate a system prompt from a `PromptSpec` |
-| `generateSystemPrompt(spec)` | Generate a system prompt from `{ library, promptOptions }`. Pass `{ cloud: true }` for OpenUI Cloud's managed config block. |
+| `generatePrompt(spec)` | Generate a system prompt from a `PromptSpec` (now deprecated) |
+| `generateSystemPrompt(spec)` | Generate a system prompt from `{ library, promptOptions }`. Pass `{ cloud: true }` for OpenUI Cloud's managed config. |
 
 **`PromptSpec`** includes component signatures, tool definitions (`ToolSpec[]`), feature flags (`toolCalls`, `bindings`, `editMode`, `inlineMode`), examples, and custom rules.
 

--- a/packages/lang-core/package.json
+++ b/packages/lang-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openuidev/lang-core",
-  "version": "0.2.16",
+  "version": "0.2.17",
   "description": "Framework-agnostic core for OpenUI Lang: parser, prompt generation, validation, and type definitions",
   "license": "MIT",
   "type": "module",

--- a/packages/lang-core/src/index.ts
+++ b/packages/lang-core/src/index.ts
@@ -63,7 +63,7 @@ export type {
   ValidationError,
   ValidationErrorCode,
 } from "./parser/types";
-export { chatLibrarySchema, validateChatLibrary } from "./parser/validate-library";
+export { validateChatLibrary } from "./parser/validate-library";
 export type { ChatLibrary, ChatLibraryIssue } from "./parser/validate-library";
 
 // ── Reactive schema marker ──

--- a/packages/lang-core/src/index.ts
+++ b/packages/lang-core/src/index.ts
@@ -29,7 +29,6 @@ export {
   toNumber,
 } from "./parser/builtins";
 export type { BuiltinDef } from "./parser/builtins";
-export { CLOUD_CHAT_LIBRARY_VERSION, CLOUD_CONFIG_MARKER } from "./parser/cloud-config";
 export { enrichErrors } from "./parser/enrich-errors";
 export { parseExpression } from "./parser/expressions";
 export { tokenize } from "./parser/lexer";

--- a/packages/lang-core/src/index.ts
+++ b/packages/lang-core/src/index.ts
@@ -63,7 +63,6 @@ export type {
   ValidationError,
   ValidationErrorCode,
 } from "./parser/types";
-export type { ChatLibrary } from "./parser/validate-library";
 
 // ── Reactive schema marker ──
 export { isReactiveSchema, markReactive } from "./reactive";

--- a/packages/lang-core/src/index.ts
+++ b/packages/lang-core/src/index.ts
@@ -63,8 +63,7 @@ export type {
   ValidationError,
   ValidationErrorCode,
 } from "./parser/types";
-export { validateChatLibrary } from "./parser/validate-library";
-export type { ChatLibrary, ChatLibraryIssue } from "./parser/validate-library";
+export type { ChatLibrary } from "./parser/validate-library";
 
 // ── Reactive schema marker ──
 export { isReactiveSchema, markReactive } from "./reactive";

--- a/packages/lang-core/src/index.ts
+++ b/packages/lang-core/src/index.ts
@@ -29,12 +29,14 @@ export {
   toNumber,
 } from "./parser/builtins";
 export type { BuiltinDef } from "./parser/builtins";
+export { CLOUD_CHAT_LIBRARY_VERSION, CLOUD_CONFIG_MARKER } from "./parser/cloud-config";
 export { enrichErrors } from "./parser/enrich-errors";
 export { parseExpression } from "./parser/expressions";
 export { tokenize } from "./parser/lexer";
 export { mergeStatements } from "./parser/merge";
 export { generatePrompt, generateSystemPrompt } from "./parser/prompt";
 export type {
+  CloudPromptOptions,
   ComponentPromptSpec,
   LibrarySpec,
   PromptSpec,
@@ -61,6 +63,8 @@ export type {
   ValidationError,
   ValidationErrorCode,
 } from "./parser/types";
+export { chatLibrarySchema, validateChatLibrary } from "./parser/validate-library";
+export type { ChatLibrary, ChatLibraryIssue } from "./parser/validate-library";
 
 // ── Reactive schema marker ──
 export { isReactiveSchema, markReactive } from "./reactive";

--- a/packages/lang-core/src/parser/__tests__/prompt.test.ts
+++ b/packages/lang-core/src/parser/__tests__/prompt.test.ts
@@ -62,14 +62,6 @@ describe("generateSystemPrompt — self-hosted", () => {
     expect(prompt).toContain("Card(children: Component[])");
     expect(prompt.startsWith(CONFIG_MARKER)).toBe(false);
   });
-
-  it("appends instructions after the local prompt", () => {
-    const prompt = generateSystemPrompt({
-      library: spec,
-      instructions: "Be terse.",
-    });
-    expect(prompt.endsWith("\nBe terse.")).toBe(true);
-  });
 });
 
 describe("generateSystemPrompt({ cloud: true }) — sentinel", () => {

--- a/packages/lang-core/src/parser/__tests__/prompt.test.ts
+++ b/packages/lang-core/src/parser/__tests__/prompt.test.ts
@@ -83,7 +83,7 @@ describe("generateSystemPrompt({ cloud: true }) — sentinel", () => {
     }
   });
 
-  it("appends customer prose after the block", () => {
+  it("appends extra prose after the block", () => {
     const out = generateSystemPrompt({ cloud: true, instructions: "Be terse." });
     const [sentinelLine, jsonLine, ...rest] = out.split("\n");
     expect(sentinelLine).toBe("]]>openui:config");

--- a/packages/lang-core/src/parser/__tests__/prompt.test.ts
+++ b/packages/lang-core/src/parser/__tests__/prompt.test.ts
@@ -3,7 +3,7 @@ import { generateSystemPrompt, type CloudPromptOptions, type LibrarySpec } from 
 
 const CONFIG_MARKER = "]]>openui:config\n";
 
-const MUSE_MANAGED_CONFIG_KEYS = [
+const CLOUD_CONFIG_KEYS = [
   "libraryVersion",
   "customComponents",
   "customActions",
@@ -84,10 +84,10 @@ describe("generateSystemPrompt({ cloud: true }) — sentinel", () => {
     expect(config.libraryVersion).toBe("0.1.0");
   });
 
-  it("emitted keys are a subset of muse MANAGED_CONFIG_KEYS", () => {
+  it("emitted keys are a subset of Cloud config keys", () => {
     const config = parseBlock(generateSystemPrompt({ cloud: true, instructions: "Be terse." }));
     for (const key of Object.keys(config)) {
-      expect(MUSE_MANAGED_CONFIG_KEYS).toContain(key);
+      expect(CLOUD_CONFIG_KEYS).toContain(key);
     }
   });
 

--- a/packages/lang-core/src/parser/__tests__/prompt.test.ts
+++ b/packages/lang-core/src/parser/__tests__/prompt.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  CLOUD_CHAT_LIBRARY_VERSION,
-  generateSystemPrompt,
-  type CloudPromptOptions,
-  type LibrarySpec,
-} from "../../index";
+import { generateSystemPrompt, type CloudPromptOptions, type LibrarySpec } from "../../index";
 
 const CONFIG_MARKER = "]]>openui:config\n";
 
@@ -86,7 +81,7 @@ describe("generateSystemPrompt({ cloud: true }) — sentinel", () => {
   it("no library → JSON with only libraryVersion", () => {
     const config = parseBlock(generateSystemPrompt({ cloud: true }));
     expect(Object.keys(config)).toEqual(["libraryVersion"]);
-    expect(config.libraryVersion).toBe(CLOUD_CHAT_LIBRARY_VERSION);
+    expect(config.libraryVersion).toBe("0.1.0");
   });
 
   it("emitted keys are a subset of muse MANAGED_CONFIG_KEYS", () => {

--- a/packages/lang-core/src/parser/__tests__/prompt.test.ts
+++ b/packages/lang-core/src/parser/__tests__/prompt.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLOUD_CHAT_LIBRARY_VERSION,
+  generateSystemPrompt,
+  type ChatLibrary,
+  type CloudPromptOptions,
+  type LibrarySpec,
+} from "../../index";
+
+const CONFIG_MARKER = "]]>openui:config\n";
+
+const MUSE_MANAGED_CONFIG_KEYS = [
+  "libraryVersion",
+  "customComponents",
+  "customActions",
+  "openrouterProvider",
+  "chatLibrary",
+  "systemPromptOptions",
+];
+
+function parseBlock(emitted: string): Record<string, unknown> {
+  expect(emitted.startsWith(CONFIG_MARKER)).toBe(true);
+  const body = emitted.slice(CONFIG_MARKER.length);
+  const firstLine = body.split("\n", 1)[0];
+  return JSON.parse(firstLine);
+}
+
+const library: ChatLibrary = {
+  root: "Card",
+  schema: {
+    $defs: {
+      Card: {
+        properties: {
+          children: {
+            type: "array",
+            items: { anyOf: [{ $ref: "#/$defs/TextContent" }] },
+          },
+          title: { type: "string" },
+        },
+        required: ["children"],
+        description: "Top-level container.",
+      },
+      TextContent: {
+        properties: { text: { type: "string" } },
+        required: ["text"],
+      },
+    },
+  },
+  componentGroups: [
+    {
+      name: "Content",
+      components: ["TextContent"],
+    },
+  ],
+};
+
+describe("generateSystemPrompt — self-hosted", () => {
+  const spec: LibrarySpec = {
+    root: "Card",
+    components: {
+      Card: { signature: "Card(children: Component[])", description: "Root" },
+    },
+  };
+
+  it("renders a local prompt from a library spec", () => {
+    const prompt = generateSystemPrompt({ library: spec });
+    expect(prompt).toContain("openui-lang");
+    expect(prompt).toContain("Card(children: Component[])");
+    expect(prompt.startsWith(CONFIG_MARKER)).toBe(false);
+  });
+
+  it("appends instructions after the local prompt", () => {
+    const prompt = generateSystemPrompt({
+      library: spec,
+      instructions: "Be terse.",
+    });
+    expect(prompt.endsWith("\nBe terse.")).toBe(true);
+  });
+});
+
+describe("generateSystemPrompt({ cloud: true }) — sentinel", () => {
+  it("starts with the byte-exact marker", () => {
+    const out = generateSystemPrompt({ cloud: true });
+    expect(out.slice(0, CONFIG_MARKER.length)).toBe(CONFIG_MARKER);
+  });
+
+  it("no library → JSON with only libraryVersion", () => {
+    const config = parseBlock(generateSystemPrompt({ cloud: true }));
+    expect(Object.keys(config)).toEqual(["libraryVersion"]);
+    expect(config.libraryVersion).toBe(CLOUD_CHAT_LIBRARY_VERSION);
+  });
+
+  it("emitted keys are a subset of muse MANAGED_CONFIG_KEYS", () => {
+    const config = parseBlock(generateSystemPrompt({ cloud: true, instructions: "Be terse." }));
+    for (const key of Object.keys(config)) {
+      expect(MUSE_MANAGED_CONFIG_KEYS).toContain(key);
+    }
+  });
+
+  it("appends customer prose after the block", () => {
+    const out = generateSystemPrompt({ cloud: true, instructions: "Be terse." });
+    const [sentinelLine, jsonLine, ...rest] = out.split("\n");
+    expect(sentinelLine).toBe("]]>openui:config");
+    expect(() => JSON.parse(jsonLine)).not.toThrow();
+    expect(rest.join("\n")).toBe("Be terse.");
+  });
+
+  it("no instructions → sentinel + JSON only", () => {
+    expect(generateSystemPrompt({ cloud: true }).split("\n")).toHaveLength(2);
+  });
+});
+
+describe("generateSystemPrompt({ cloud: true, library })", () => {
+  it("emits the library under chatLibrary, dropping components", () => {
+    const specJson = {
+      ...library,
+      components: {
+        Card: { signature: "Card(children: (TextContent)[], title?: string)" },
+      },
+    };
+    const config = parseBlock(generateSystemPrompt({ cloud: true, library: specJson }));
+    expect((config.chatLibrary as Record<string, unknown>).components).toBeUndefined();
+    expect(config.chatLibrary).toEqual(library);
+    expect(Object.keys(config)).toEqual(["chatLibrary"]);
+  });
+
+  it("systemPromptOptions rides as a sibling key", () => {
+    const config = parseBlock(
+      generateSystemPrompt({
+        cloud: true,
+        library,
+        promptOptions: { preamble: "You generate UI for Acme." },
+      }),
+    );
+    expect(Object.keys(config)).toEqual(["chatLibrary", "systemPromptOptions"]);
+    expect(config.systemPromptOptions).toEqual({ preamble: "You generate UI for Acme." });
+  });
+
+  it("strips Cloud-unsupported prompt flags from the wire", () => {
+    const config = parseBlock(
+      generateSystemPrompt({
+        cloud: true,
+        library,
+        promptOptions: {
+          preamble: "Acme.",
+          editMode: true,
+          tools: ["search"],
+        } as CloudPromptOptions,
+      }),
+    );
+    expect(config.systemPromptOptions).toEqual({ preamble: "Acme." });
+  });
+
+  it("promptOptions without a library throws", () => {
+    expect(() =>
+      generateSystemPrompt({
+        cloud: true,
+        promptOptions: { preamble: "Nope." },
+      }),
+    ).toThrowError(/promptOptions requires a library/);
+  });
+
+  it("invalid library throws with every issue", () => {
+    const broken: ChatLibrary = {
+      root: "Missing",
+      schema: {
+        $defs: {
+          Card: {
+            properties: { body: { $ref: "#/$defs/Nope" } },
+            required: ["ghost"],
+          },
+        },
+      },
+    };
+    expect(() => generateSystemPrompt({ cloud: true, library: broken })).toThrowError(
+      /Invalid library/,
+    );
+    expect(() => generateSystemPrompt({ cloud: true, library: broken })).toThrowError(
+      /Root component "Missing"/,
+    );
+    expect(() => generateSystemPrompt({ cloud: true, library: broken })).toThrowError(
+      /Unresolvable \$ref "#\/\$defs\/Nope"/,
+    );
+    expect(() => generateSystemPrompt({ cloud: true, library: broken })).toThrowError(
+      /required property "ghost"/,
+    );
+  });
+});

--- a/packages/lang-core/src/parser/__tests__/prompt.test.ts
+++ b/packages/lang-core/src/parser/__tests__/prompt.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   CLOUD_CHAT_LIBRARY_VERSION,
   generateSystemPrompt,
-  type ChatLibrary,
   type CloudPromptOptions,
   type LibrarySpec,
 } from "../../index";
@@ -25,7 +24,7 @@ function parseBlock(emitted: string): Record<string, unknown> {
   return JSON.parse(firstLine);
 }
 
-const library: ChatLibrary = {
+const library = {
   root: "Card",
   schema: {
     $defs: {
@@ -52,7 +51,7 @@ const library: ChatLibrary = {
       components: ["TextContent"],
     },
   ],
-};
+} as LibrarySpec;
 
 describe("generateSystemPrompt — self-hosted", () => {
   const spec: LibrarySpec = {
@@ -161,8 +160,9 @@ describe("generateSystemPrompt({ cloud: true, library })", () => {
   });
 
   it("invalid library throws with every issue", () => {
-    const broken: ChatLibrary = {
+    const broken: LibrarySpec = {
       root: "Missing",
+      components: {},
       schema: {
         $defs: {
           Card: {

--- a/packages/lang-core/src/parser/cloud-config.ts
+++ b/packages/lang-core/src/parser/cloud-config.ts
@@ -6,7 +6,7 @@ const CLOUD_CONFIG_MARKER = "]]>openui:config\n";
 
 /**
  * Wire pin for OpenUI Cloud's built-in chat library when `generateSystemPrompt({ cloud: true })`
- * is called without a custom library. Muse 400s on a non-numeric or too-old version.
+ * is called without a custom library. Cloud rejects a non-numeric or too-old version.
  */
 const CLOUD_CHAT_LIBRARY_VERSION = "0.1.0";
 

--- a/packages/lang-core/src/parser/cloud-config.ts
+++ b/packages/lang-core/src/parser/cloud-config.ts
@@ -6,7 +6,7 @@ const CLOUD_CONFIG_MARKER = "]]>openui:config\n";
 
 /**
  * Wire pin for OpenUI Cloud's built-in chat library when `generateSystemPrompt({ cloud: true })`
- * is called without a custom library. Cloud rejects a non-numeric or too-old version.
+ * is called without your own library. Cloud rejects a non-numeric or too-old version.
  */
 const CLOUD_CHAT_LIBRARY_VERSION = "0.1.0";
 

--- a/packages/lang-core/src/parser/cloud-config.ts
+++ b/packages/lang-core/src/parser/cloud-config.ts
@@ -1,0 +1,66 @@
+import type { CloudPromptOptions, SystemPromptOptions } from "./prompt";
+import { type ChatLibrary, validateChatLibrary } from "./validate-library";
+
+/** `]]>openui:config\n` — request-direction config block header. Trailing newline is part of the wire contract. */
+export const CLOUD_CONFIG_MARKER = "]]>openui:config\n";
+
+/**
+ * Wire pin for OpenUI Cloud's built-in chat library when `generateSystemPrompt({ cloud: true })`
+ * is called without a custom library. Muse 400s on a non-numeric or too-old version.
+ */
+export const CLOUD_CHAT_LIBRARY_VERSION = "0.1.0";
+
+type CloudConfig =
+  | { libraryVersion: string }
+  | { chatLibrary: CloudChatLibraryWire; systemPromptOptions?: CloudPromptOptions };
+
+type CloudChatLibraryWire = {
+  schema?: ChatLibrary["schema"];
+  root?: string;
+  componentGroups?: ChatLibrary["componentGroups"];
+  id?: string;
+};
+
+function pickCloudPromptOptions(
+  options: SystemPromptOptions | CloudPromptOptions | undefined,
+): CloudPromptOptions | undefined {
+  if (!options) return undefined;
+  const picked: CloudPromptOptions = {};
+  if (options.examples) picked.examples = options.examples;
+  if (options.preamble) picked.preamble = options.preamble;
+  if (options.additionalRules) picked.additionalRules = options.additionalRules;
+  return Object.keys(picked).length > 0 ? picked : undefined;
+}
+
+export function generateCloudConfig(spec: {
+  library?: ChatLibrary;
+  promptOptions?: SystemPromptOptions | CloudPromptOptions;
+  instructions?: string;
+}): string {
+  let config: CloudConfig;
+
+  if (spec.library) {
+    const issues = validateChatLibrary(spec.library);
+    if (issues.length > 0) {
+      throw new Error(
+        `[generateSystemPrompt] Invalid library: ${issues.map((i) => i.message).join(" ")}`,
+      );
+    }
+    const { schema, root, componentGroups, id } = spec.library;
+    const promptOptions = pickCloudPromptOptions(spec.promptOptions);
+    config = {
+      chatLibrary: { schema, root, componentGroups, id },
+      ...(promptOptions ? { systemPromptOptions: promptOptions } : {}),
+    };
+  } else {
+    if (spec.promptOptions && pickCloudPromptOptions(spec.promptOptions)) {
+      throw new Error(
+        "[generateSystemPrompt] promptOptions requires a library — the built-in library ignores it.",
+      );
+    }
+    config = { libraryVersion: CLOUD_CHAT_LIBRARY_VERSION };
+  }
+
+  const block = `${CLOUD_CONFIG_MARKER}${JSON.stringify(config)}`;
+  return spec.instructions ? `${block}\n${spec.instructions}` : block;
+}

--- a/packages/lang-core/src/parser/cloud-config.ts
+++ b/packages/lang-core/src/parser/cloud-config.ts
@@ -1,5 +1,5 @@
-import type { CloudPromptOptions, SystemPromptOptions } from "./prompt";
-import { type ChatLibrary, validateChatLibrary } from "./validate-library";
+import type { CloudPromptOptions, LibrarySpec, SystemPromptOptions } from "./prompt";
+import { validateChatLibrary } from "./validate-library";
 
 /** `]]>openui:config\n` — request-direction config block header. Trailing newline is part of the wire contract. */
 export const CLOUD_CONFIG_MARKER = "]]>openui:config\n";
@@ -12,14 +12,7 @@ export const CLOUD_CHAT_LIBRARY_VERSION = "0.1.0";
 
 type CloudConfig =
   | { libraryVersion: string }
-  | { chatLibrary: CloudChatLibraryWire; systemPromptOptions?: CloudPromptOptions };
-
-type CloudChatLibraryWire = {
-  schema?: ChatLibrary["schema"];
-  root?: string;
-  componentGroups?: ChatLibrary["componentGroups"];
-  id?: string;
-};
+  | { chatLibrary: Omit<LibrarySpec, "components">; systemPromptOptions?: CloudPromptOptions };
 
 function pickCloudPromptOptions(
   options: SystemPromptOptions | CloudPromptOptions | undefined,
@@ -33,7 +26,7 @@ function pickCloudPromptOptions(
 }
 
 export function generateCloudConfig(spec: {
-  library?: ChatLibrary;
+  library?: LibrarySpec;
   promptOptions?: SystemPromptOptions | CloudPromptOptions;
   instructions?: string;
 }): string {
@@ -46,10 +39,10 @@ export function generateCloudConfig(spec: {
         `[generateSystemPrompt] Invalid library: ${issues.map((i) => i.message).join(" ")}`,
       );
     }
-    const { schema, root, componentGroups, id } = spec.library;
+    const { components: _components, ...chatLibrary } = spec.library;
     const promptOptions = pickCloudPromptOptions(spec.promptOptions);
     config = {
-      chatLibrary: { schema, root, componentGroups, id },
+      chatLibrary,
       ...(promptOptions ? { systemPromptOptions: promptOptions } : {}),
     };
   } else {

--- a/packages/lang-core/src/parser/cloud-config.ts
+++ b/packages/lang-core/src/parser/cloud-config.ts
@@ -2,13 +2,13 @@ import type { CloudPromptOptions, LibrarySpec, SystemPromptOptions } from "./pro
 import { validateChatLibrary } from "./validate-library";
 
 /** `]]>openui:config\n` — request-direction config block header. Trailing newline is part of the wire contract. */
-export const CLOUD_CONFIG_MARKER = "]]>openui:config\n";
+const CLOUD_CONFIG_MARKER = "]]>openui:config\n";
 
 /**
  * Wire pin for OpenUI Cloud's built-in chat library when `generateSystemPrompt({ cloud: true })`
  * is called without a custom library. Muse 400s on a non-numeric or too-old version.
  */
-export const CLOUD_CHAT_LIBRARY_VERSION = "0.1.0";
+const CLOUD_CHAT_LIBRARY_VERSION = "0.1.0";
 
 type CloudConfig =
   | { libraryVersion: string }

--- a/packages/lang-core/src/parser/prompt.ts
+++ b/packages/lang-core/src/parser/prompt.ts
@@ -1,6 +1,8 @@
 import { recordSystemPromptGeneration } from "../telemetry/runtime";
 import { BUILTINS, LAZY_BUILTIN_DEFS } from "./builtins";
+import { generateCloudConfig } from "./cloud-config";
 import type { LibraryJSONSchema } from "./types";
+import type { ChatLibrary } from "./validate-library";
 
 // ─── PromptSpec types (JSON-serializable, no Zod deps) ──────────────────────
 
@@ -699,18 +701,45 @@ export function generatePrompt(spec: PromptSpec): string {
 /** Prompt options for {@link generateSystemPrompt} */
 export type SystemPromptOptions = Omit<PromptSpec, keyof BaseSpec>;
 
-/** Object input for {@link generateSystemPrompt}. */
-export interface SystemPromptSpec {
-  library: LibrarySpec;
-  promptOptions?: SystemPromptOptions;
-}
+/**
+ * Prompt options allowed on the OpenUI Cloud wire. Extra flags (`tools`,
+ * `editMode`, …) are stripped — Cloud's built-in prompt assembler ignores them.
+ */
+export type CloudPromptOptions = Pick<
+  SystemPromptOptions,
+  "examples" | "preamble" | "additionalRules"
+>;
 
-/** Render the full system prompt for a library. */
+/**
+ * Object input for {@link generateSystemPrompt}.
+ *
+ * Pass `cloud: true` to emit OpenUI Cloud's managed `]]>openui:config` block
+ * instead of a locally generated prompt. In that mode `library` is optional —
+ * omit it to use Cloud's built-in chat library.
+ */
+export type SystemPromptSpec =
+  | {
+      library: LibrarySpec;
+      promptOptions?: SystemPromptOptions;
+      instructions?: string;
+      cloud?: false;
+    }
+  | {
+      cloud: true;
+      library?: ChatLibrary;
+      promptOptions?: CloudPromptOptions;
+      instructions?: string;
+    };
+
+/** Render the full system prompt for a library, or Cloud's managed config block when `cloud: true`. */
 export function generateSystemPrompt(spec: SystemPromptSpec): string;
 /** @deprecated Pass `{ library, promptOptions, instructions }` instead. Removed at the next major. */
 export function generateSystemPrompt(spec: PromptSpec): string;
 export function generateSystemPrompt(spec: SystemPromptSpec | PromptSpec): string {
-  if (!isSystemPromptSpec(spec)) {
+  if (isCloudSpec(spec)) {
+    return generateCloudConfig(spec);
+  }
+  if (!isLocalSystemPromptSpec(spec)) {
     const prompt = generatePrompt(spec);
     recordSystemPromptGeneration(spec, "legacy_prompt_spec");
     return prompt;
@@ -718,10 +747,17 @@ export function generateSystemPrompt(spec: SystemPromptSpec | PromptSpec): strin
   const merged: PromptSpec = { ...spec.library, ...spec.promptOptions };
   const prompt = generatePrompt(merged);
   recordSystemPromptGeneration(merged, "library_spec");
-  return prompt;
+  return spec.instructions ? `${prompt}\n${spec.instructions}` : prompt;
 }
 
-// use `library` to discriminate SystemPromptSpec from the deprecated base-PromptSpec
-function isSystemPromptSpec(spec: SystemPromptSpec | PromptSpec): spec is SystemPromptSpec {
-  return "library" in spec && typeof (spec as SystemPromptSpec).library === "object";
+function isCloudSpec(
+  spec: SystemPromptSpec | PromptSpec,
+): spec is Extract<SystemPromptSpec, { cloud: true }> {
+  return "cloud" in spec && (spec as { cloud?: unknown }).cloud === true;
+}
+
+function isLocalSystemPromptSpec(
+  spec: SystemPromptSpec | PromptSpec,
+): spec is Extract<SystemPromptSpec, { library: LibrarySpec }> {
+  return "library" in spec && typeof (spec as { library?: unknown }).library === "object";
 }

--- a/packages/lang-core/src/parser/prompt.ts
+++ b/packages/lang-core/src/parser/prompt.ts
@@ -695,7 +695,7 @@ export function generatePrompt(spec: PromptSpec): string {
   return parts.join("\n");
 }
 
-// ─── System prompt (library + options + instructions) ───────────────────────
+// ─── System prompt (library + options) ──────────────────────────────────────
 
 /** Prompt options for {@link generateSystemPrompt} */
 export type SystemPromptOptions = Omit<PromptSpec, keyof BaseSpec>;
@@ -714,13 +714,13 @@ export type CloudPromptOptions = Pick<
  *
  * Pass `cloud: true` to emit OpenUI Cloud's managed `]]>openui:config` block
  * instead of a locally generated prompt. In that mode `library` is optional —
- * omit it to use Cloud's built-in chat library.
+ * omit it to use Cloud's built-in chat library. `instructions` is Cloud-only
+ * extra prose appended after the config block.
  */
 export type SystemPromptSpec =
   | {
       library: LibrarySpec;
       promptOptions?: SystemPromptOptions;
-      instructions?: string;
       cloud?: false;
     }
   | {
@@ -732,7 +732,7 @@ export type SystemPromptSpec =
 
 /** Render the full system prompt for a library, or Cloud's managed config block when `cloud: true`. */
 export function generateSystemPrompt(spec: SystemPromptSpec): string;
-/** @deprecated Pass `{ library, promptOptions, instructions }` instead. Removed at the next major. */
+/** @deprecated Pass `{ library, promptOptions }` instead. Removed at the next major. */
 export function generateSystemPrompt(spec: PromptSpec): string;
 export function generateSystemPrompt(spec: SystemPromptSpec | PromptSpec): string {
   if (isCloudSpec(spec)) {
@@ -746,7 +746,7 @@ export function generateSystemPrompt(spec: SystemPromptSpec | PromptSpec): strin
   const merged: PromptSpec = { ...spec.library, ...spec.promptOptions };
   const prompt = generatePrompt(merged);
   recordSystemPromptGeneration(merged, "library_spec");
-  return spec.instructions ? `${prompt}\n${spec.instructions}` : prompt;
+  return prompt;
 }
 
 function isCloudSpec(

--- a/packages/lang-core/src/parser/prompt.ts
+++ b/packages/lang-core/src/parser/prompt.ts
@@ -2,7 +2,6 @@ import { recordSystemPromptGeneration } from "../telemetry/runtime";
 import { BUILTINS, LAZY_BUILTIN_DEFS } from "./builtins";
 import { generateCloudConfig } from "./cloud-config";
 import type { LibraryJSONSchema } from "./types";
-import type { ChatLibrary } from "./validate-library";
 
 // ─── PromptSpec types (JSON-serializable, no Zod deps) ──────────────────────
 
@@ -726,7 +725,7 @@ export type SystemPromptSpec =
     }
   | {
       cloud: true;
-      library?: ChatLibrary;
+      library?: LibrarySpec;
       promptOptions?: CloudPromptOptions;
       instructions?: string;
     };
@@ -739,7 +738,7 @@ export function generateSystemPrompt(spec: SystemPromptSpec | PromptSpec): strin
   if (isCloudSpec(spec)) {
     return generateCloudConfig(spec);
   }
-  if (!isLocalSystemPromptSpec(spec)) {
+  if (!isSystemPromptSpec(spec)) {
     const prompt = generatePrompt(spec);
     recordSystemPromptGeneration(spec, "legacy_prompt_spec");
     return prompt;
@@ -756,7 +755,7 @@ function isCloudSpec(
   return "cloud" in spec && (spec as { cloud?: unknown }).cloud === true;
 }
 
-function isLocalSystemPromptSpec(
+function isSystemPromptSpec(
   spec: SystemPromptSpec | PromptSpec,
 ): spec is Extract<SystemPromptSpec, { library: LibrarySpec }> {
   return "library" in spec && typeof (spec as { library?: unknown }).library === "object";

--- a/packages/lang-core/src/parser/validate-library.ts
+++ b/packages/lang-core/src/parser/validate-library.ts
@@ -4,12 +4,6 @@
  */
 import type { LibrarySpec } from "./prompt";
 
-/**
- * Wire shape of a serialized chat library (the `]]>openui:config` `chatLibrary`
- * value). Same as {@link LibrarySpec} without prompt-side `components`.
- */
-export type ChatLibrary = Omit<LibrarySpec, "components">;
-
 export interface ChatLibraryIssue {
   code:
     | "invalid-shape"
@@ -63,7 +57,7 @@ function collectRefIssues(
  * Structural validation of a customer-supplied design-system library.
  * Returns ALL issues found (empty array = valid).
  */
-export function validateChatLibrary(library: ChatLibrary): ChatLibraryIssue[] {
+export function validateChatLibrary(library: LibrarySpec): ChatLibraryIssue[] {
   const issues: ChatLibraryIssue[] = [];
 
   if (!isPlainObject(library)) {

--- a/packages/lang-core/src/parser/validate-library.ts
+++ b/packages/lang-core/src/parser/validate-library.ts
@@ -1,4 +1,7 @@
-import { z } from "zod/v4";
+/**
+ * Structural validator for a customer-supplied design-system library.
+ * Hand-rolled walker — reports every issue in one pass.
+ */
 import type { LibrarySpec } from "./prompt";
 
 /**
@@ -25,124 +28,15 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-const componentGroupSchema = z.object({
-  name: z.string(),
-  components: z.array(z.string()),
-  notes: z.array(z.string()).optional(),
-});
-
-/**
- * Structural + semantic schema for a customer-supplied chat library.
- * Shape is Zod; `$ref` / root / required / group membership are refinements
- * so every issue is reported (not fail-fast).
- */
-export const chatLibrarySchema = z
-  .object({
-    root: z
-      .string()
-      .min(1, "chatLibrary.root, when present, must be a non-empty string.")
-      .optional(),
-    id: z.string().optional(),
-    // generate-spec / toSpec() leftover — accepted, never required on the wire
-    components: z.unknown().optional(),
-    schema: z
-      .object({
-        $defs: z.record(z.string(), z.unknown()).refine((defs) => Object.keys(defs).length > 0, {
-          message: "chatLibrary.schema.$defs must be a non-empty object keyed by component name.",
-        }),
-      })
-      .passthrough(),
-    componentGroups: z.array(componentGroupSchema).optional(),
-  })
-  .passthrough()
-  .superRefine((library, ctx) => {
-    const defs = library.schema.$defs;
-    const defNames = new Set(Object.keys(defs));
-
-    const add = (issue: ChatLibraryIssue) => {
-      ctx.addIssue({
-        code: "custom",
-        message: issue.message,
-        path: issue.path ? issue.path.split("/") : [],
-        params: { issueCode: issue.code },
-      });
-    };
-
-    if (library.root && !defNames.has(library.root)) {
-      add({
-        code: "root-not-found",
-        message: `Root component "${library.root}" was not found in schema.$defs. Available components: ${[...defNames].join(", ")}.`,
-        path: "root",
-      });
-    }
-
-    for (const [name, def] of Object.entries(defs)) {
-      const defPath = `$defs/${name}`;
-      if (!isPlainObject(def)) {
-        add({
-          code: "invalid-shape",
-          message: `${defPath} must be an object component schema.`,
-          path: defPath,
-        });
-        continue;
-      }
-
-      const properties = def["properties"];
-      if (properties !== undefined && !isPlainObject(properties)) {
-        add({
-          code: "invalid-shape",
-          message: `${defPath}/properties must be an object.`,
-          path: `${defPath}/properties`,
-        });
-      }
-
-      const required = def["required"];
-      if (required !== undefined) {
-        if (!Array.isArray(required) || required.some((r) => typeof r !== "string")) {
-          add({
-            code: "invalid-required",
-            message: `${defPath}/required must be an array of property names.`,
-            path: `${defPath}/required`,
-          });
-        } else {
-          const propKeys = new Set(isPlainObject(properties) ? Object.keys(properties) : []);
-          for (const r of required) {
-            if (!propKeys.has(r)) {
-              add({
-                code: "invalid-required",
-                message: `${defPath} lists required property "${r}" that is not in properties.`,
-                path: `${defPath}/required`,
-              });
-            }
-          }
-        }
-      }
-
-      collectRefIssues(properties, `${defPath}/properties`, defNames, add);
-    }
-
-    for (const [index, group] of (library.componentGroups ?? []).entries()) {
-      for (const comp of group.components) {
-        if (!defNames.has(comp)) {
-          add({
-            code: "unknown-group-component",
-            message: `Component group "${group.name}" references unknown component "${comp}".`,
-            path: `componentGroups/${index}`,
-          });
-        }
-      }
-    }
-  });
-
 /** Recursively collect every `$ref` and check it resolves within `$defs`. */
 function collectRefIssues(
   node: unknown,
   path: string,
   defNames: Set<string>,
-  add: (issue: ChatLibraryIssue) => void,
+  issues: ChatLibraryIssue[],
 ): void {
   if (Array.isArray(node)) {
-    node.forEach((item, i) => collectRefIssues(item, `${path}/${i}`, defNames, add));
+    node.forEach((item, i) => collectRefIssues(item, `${path}/${i}`, defNames, issues));
     return;
   }
   if (!isPlainObject(node)) return;
@@ -151,7 +45,7 @@ function collectRefIssues(
   if (typeof ref === "string") {
     const match = REF_PATTERN.exec(ref);
     if (!match || !defNames.has(match[1] as string)) {
-      add({
+      issues.push({
         code: "unresolved-ref",
         message: `Unresolvable $ref "${ref}" at ${path} — refs must be "#/$defs/<name>" pointing at a component in $defs.`,
         path,
@@ -161,30 +55,8 @@ function collectRefIssues(
 
   for (const [key, value] of Object.entries(node)) {
     if (key === "$ref") continue;
-    collectRefIssues(value, `${path}/${key}`, defNames, add);
+    collectRefIssues(value, `${path}/${key}`, defNames, issues);
   }
-}
-
-function pathOf(issue: z.core.$ZodIssue): string | undefined {
-  return issue.path.length > 0 ? issue.path.map(String).join("/") : undefined;
-}
-
-function shapeMessage(issue: z.core.$ZodIssue, path: string | undefined): string {
-  if (path === "root" || path?.startsWith("root")) {
-    return "chatLibrary.root, when present, must be a non-empty string.";
-  }
-  if (path === "schema" || path?.startsWith("schema")) {
-    if (path === "schema/$defs" || path === "schema.$defs") {
-      return "chatLibrary.schema.$defs must be a non-empty object keyed by component name.";
-    }
-    if (path === "schema" || issue.code === "invalid_type") {
-      return "chatLibrary.schema must be an object with a $defs map of component schemas.";
-    }
-  }
-  if (path?.startsWith("componentGroups")) {
-    return "Each componentGroups entry must be {name: string, components: string[], notes?: string[]}.";
-  }
-  return issue.message;
 }
 
 /**
@@ -192,6 +64,8 @@ function shapeMessage(issue: z.core.$ZodIssue, path: string | undefined): string
  * Returns ALL issues found (empty array = valid).
  */
 export function validateChatLibrary(library: ChatLibrary): ChatLibraryIssue[] {
+  const issues: ChatLibraryIssue[] = [];
+
   if (!isPlainObject(library)) {
     return [
       {
@@ -201,17 +75,114 @@ export function validateChatLibrary(library: ChatLibrary): ChatLibraryIssue[] {
     ];
   }
 
-  const result = chatLibrarySchema.safeParse(library);
-  if (result.success) return [];
+  const { root, schema, componentGroups } = library;
 
-  return result.error.issues.map((issue) => {
-    const issueCode = (issue as { params?: { issueCode?: ChatLibraryIssue["code"] } }).params
-      ?.issueCode;
-    const path = pathOf(issue);
-    return {
-      code: issueCode ?? "invalid-shape",
-      message: issueCode ? issue.message : shapeMessage(issue, path),
-      path,
-    };
-  });
+  if (root !== undefined && (typeof root !== "string" || root.length === 0)) {
+    issues.push({
+      code: "invalid-shape",
+      message: "chatLibrary.root, when present, must be a non-empty string.",
+      path: "root",
+    });
+  }
+
+  if (!isPlainObject(schema)) {
+    issues.push({
+      code: "invalid-shape",
+      message: "chatLibrary.schema must be an object with a $defs map of component schemas.",
+      path: "schema",
+    });
+    return issues;
+  }
+
+  const defs = schema.$defs;
+  if (!isPlainObject(defs) || Object.keys(defs).length === 0) {
+    issues.push({
+      code: "invalid-shape",
+      message: "chatLibrary.schema.$defs must be a non-empty object keyed by component name.",
+      path: "schema/$defs",
+    });
+    return issues;
+  }
+
+  const defNames = new Set(Object.keys(defs));
+
+  if (typeof root === "string" && root.length > 0 && !defNames.has(root)) {
+    issues.push({
+      code: "root-not-found",
+      message: `Root component "${root}" was not found in schema.$defs. Available components: ${[...defNames].join(", ")}.`,
+      path: "root",
+    });
+  }
+
+  for (const [name, def] of Object.entries(defs)) {
+    const defPath = `$defs/${name}`;
+    if (!isPlainObject(def)) {
+      issues.push({
+        code: "invalid-shape",
+        message: `${defPath} must be an object component schema.`,
+        path: defPath,
+      });
+      continue;
+    }
+
+    const properties = def["properties"];
+    if (properties !== undefined && !isPlainObject(properties)) {
+      issues.push({
+        code: "invalid-shape",
+        message: `${defPath}/properties must be an object.`,
+        path: `${defPath}/properties`,
+      });
+    }
+
+    const required = def["required"];
+    if (required !== undefined) {
+      if (!Array.isArray(required) || required.some((r) => typeof r !== "string")) {
+        issues.push({
+          code: "invalid-required",
+          message: `${defPath}/required must be an array of property names.`,
+          path: `${defPath}/required`,
+        });
+      } else {
+        const propKeys = new Set(isPlainObject(properties) ? Object.keys(properties) : []);
+        for (const r of required) {
+          if (!propKeys.has(r)) {
+            issues.push({
+              code: "invalid-required",
+              message: `${defPath} lists required property "${r}" that is not in properties.`,
+              path: `${defPath}/required`,
+            });
+          }
+        }
+      }
+    }
+
+    collectRefIssues(properties, `${defPath}/properties`, defNames, issues);
+  }
+
+  for (const group of componentGroups ?? []) {
+    if (
+      !isPlainObject(group) ||
+      typeof group.name !== "string" ||
+      !Array.isArray(group.components)
+    ) {
+      issues.push({
+        code: "invalid-shape",
+        message:
+          "Each componentGroups entry must be {name: string, components: string[], notes?: string[]}.",
+        path: "componentGroups",
+      });
+      continue;
+    }
+    for (const comp of group.components) {
+      if (typeof comp !== "string" || !defNames.has(comp)) {
+        issues.push({
+          code: "unknown-group-component",
+          message: `Component group "${group.name}" references unknown component "${String(comp)}".`,
+          path: "componentGroups",
+        });
+      }
+    }
+  }
+
+  return issues;
 }

--- a/packages/lang-core/src/parser/validate-library.ts
+++ b/packages/lang-core/src/parser/validate-library.ts
@@ -1,0 +1,217 @@
+import { z } from "zod/v4";
+import type { LibrarySpec } from "./prompt";
+
+/**
+ * Wire shape of a serialized chat library (the `]]>openui:config` `chatLibrary`
+ * value). Same as {@link LibrarySpec} without prompt-side `components`.
+ */
+export type ChatLibrary = Omit<LibrarySpec, "components">;
+
+export interface ChatLibraryIssue {
+  code:
+    | "invalid-shape"
+    | "root-not-found"
+    | "unresolved-ref"
+    | "unknown-group-component"
+    | "invalid-required";
+  message: string;
+  /** e.g. "$defs/Card/properties/children/items" */
+  path?: string;
+}
+
+const REF_PATTERN = /^#\/\$defs\/(.+)$/;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+const componentGroupSchema = z.object({
+  name: z.string(),
+  components: z.array(z.string()),
+  notes: z.array(z.string()).optional(),
+});
+
+/**
+ * Structural + semantic schema for a customer-supplied chat library.
+ * Shape is Zod; `$ref` / root / required / group membership are refinements
+ * so every issue is reported (not fail-fast).
+ */
+export const chatLibrarySchema = z
+  .object({
+    root: z
+      .string()
+      .min(1, "chatLibrary.root, when present, must be a non-empty string.")
+      .optional(),
+    id: z.string().optional(),
+    // generate-spec / toSpec() leftover — accepted, never required on the wire
+    components: z.unknown().optional(),
+    schema: z
+      .object({
+        $defs: z.record(z.string(), z.unknown()).refine((defs) => Object.keys(defs).length > 0, {
+          message: "chatLibrary.schema.$defs must be a non-empty object keyed by component name.",
+        }),
+      })
+      .passthrough(),
+    componentGroups: z.array(componentGroupSchema).optional(),
+  })
+  .passthrough()
+  .superRefine((library, ctx) => {
+    const defs = library.schema.$defs;
+    const defNames = new Set(Object.keys(defs));
+
+    const add = (issue: ChatLibraryIssue) => {
+      ctx.addIssue({
+        code: "custom",
+        message: issue.message,
+        path: issue.path ? issue.path.split("/") : [],
+        params: { issueCode: issue.code },
+      });
+    };
+
+    if (library.root && !defNames.has(library.root)) {
+      add({
+        code: "root-not-found",
+        message: `Root component "${library.root}" was not found in schema.$defs. Available components: ${[...defNames].join(", ")}.`,
+        path: "root",
+      });
+    }
+
+    for (const [name, def] of Object.entries(defs)) {
+      const defPath = `$defs/${name}`;
+      if (!isPlainObject(def)) {
+        add({
+          code: "invalid-shape",
+          message: `${defPath} must be an object component schema.`,
+          path: defPath,
+        });
+        continue;
+      }
+
+      const properties = def["properties"];
+      if (properties !== undefined && !isPlainObject(properties)) {
+        add({
+          code: "invalid-shape",
+          message: `${defPath}/properties must be an object.`,
+          path: `${defPath}/properties`,
+        });
+      }
+
+      const required = def["required"];
+      if (required !== undefined) {
+        if (!Array.isArray(required) || required.some((r) => typeof r !== "string")) {
+          add({
+            code: "invalid-required",
+            message: `${defPath}/required must be an array of property names.`,
+            path: `${defPath}/required`,
+          });
+        } else {
+          const propKeys = new Set(isPlainObject(properties) ? Object.keys(properties) : []);
+          for (const r of required) {
+            if (!propKeys.has(r)) {
+              add({
+                code: "invalid-required",
+                message: `${defPath} lists required property "${r}" that is not in properties.`,
+                path: `${defPath}/required`,
+              });
+            }
+          }
+        }
+      }
+
+      collectRefIssues(properties, `${defPath}/properties`, defNames, add);
+    }
+
+    for (const [index, group] of (library.componentGroups ?? []).entries()) {
+      for (const comp of group.components) {
+        if (!defNames.has(comp)) {
+          add({
+            code: "unknown-group-component",
+            message: `Component group "${group.name}" references unknown component "${comp}".`,
+            path: `componentGroups/${index}`,
+          });
+        }
+      }
+    }
+  });
+
+/** Recursively collect every `$ref` and check it resolves within `$defs`. */
+function collectRefIssues(
+  node: unknown,
+  path: string,
+  defNames: Set<string>,
+  add: (issue: ChatLibraryIssue) => void,
+): void {
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => collectRefIssues(item, `${path}/${i}`, defNames, add));
+    return;
+  }
+  if (!isPlainObject(node)) return;
+
+  const ref = node["$ref"];
+  if (typeof ref === "string") {
+    const match = REF_PATTERN.exec(ref);
+    if (!match || !defNames.has(match[1] as string)) {
+      add({
+        code: "unresolved-ref",
+        message: `Unresolvable $ref "${ref}" at ${path} — refs must be "#/$defs/<name>" pointing at a component in $defs.`,
+        path,
+      });
+    }
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === "$ref") continue;
+    collectRefIssues(value, `${path}/${key}`, defNames, add);
+  }
+}
+
+function pathOf(issue: z.core.$ZodIssue): string | undefined {
+  return issue.path.length > 0 ? issue.path.map(String).join("/") : undefined;
+}
+
+function shapeMessage(issue: z.core.$ZodIssue, path: string | undefined): string {
+  if (path === "root" || path?.startsWith("root")) {
+    return "chatLibrary.root, when present, must be a non-empty string.";
+  }
+  if (path === "schema" || path?.startsWith("schema")) {
+    if (path === "schema/$defs" || path === "schema.$defs") {
+      return "chatLibrary.schema.$defs must be a non-empty object keyed by component name.";
+    }
+    if (path === "schema" || issue.code === "invalid_type") {
+      return "chatLibrary.schema must be an object with a $defs map of component schemas.";
+    }
+  }
+  if (path?.startsWith("componentGroups")) {
+    return "Each componentGroups entry must be {name: string, components: string[], notes?: string[]}.";
+  }
+  return issue.message;
+}
+
+/**
+ * Structural validation of a customer-supplied design-system library.
+ * Returns ALL issues found (empty array = valid).
+ */
+export function validateChatLibrary(library: ChatLibrary): ChatLibraryIssue[] {
+  if (!isPlainObject(library)) {
+    return [
+      {
+        code: "invalid-shape",
+        message: "chatLibrary must be an object.",
+      },
+    ];
+  }
+
+  const result = chatLibrarySchema.safeParse(library);
+  if (result.success) return [];
+
+  return result.error.issues.map((issue) => {
+    const issueCode = (issue as { params?: { issueCode?: ChatLibraryIssue["code"] } }).params
+      ?.issueCode;
+    const path = pathOf(issue);
+    return {
+      code: issueCode ?? "invalid-shape",
+      message: issueCode ? issue.message : shapeMessage(issue, path),
+      path,
+    };
+  });
+}

--- a/packages/lang-core/src/parser/validate-library.ts
+++ b/packages/lang-core/src/parser/validate-library.ts
@@ -1,5 +1,5 @@
 /**
- * Structural validator for a customer-supplied design-system library.
+ * Structural validator for your own library.
  * Hand-rolled walker — reports every issue in one pass.
  */
 import type { LibrarySpec } from "./prompt";
@@ -54,7 +54,7 @@ function collectRefIssues(
 }
 
 /**
- * Structural validation of a customer-supplied design-system library.
+ * Structural validation of your own library.
  * Returns ALL issues found (empty array = valid).
  */
 export function validateChatLibrary(library: LibrarySpec): ChatLibraryIssue[] {


### PR DESCRIPTION
## Summary
- `generateSystemPrompt({ cloud: true })` in lang-core now emits Cloud's config sentinel instead of a locally generated prompt.
- Custom libraries still go on the wire as `{ chatLibrary, systemPromptOptions }`; docs updated to match.

## Test plan
- [ ] `cd packages/lang-core && pnpm test` (prompt tests)
- [ ] Confirm `generateSystemPrompt({ cloud: true })` starts with `]]>openui:config`
- [ ] Confirm a custom library + `promptOptions` only sends preamble / examples / additionalRules