### PR TITLE
chore(docs): bump @openuidev/thesys-server to 0.1.4

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
     "@openuidev/react-lang": "workspace:^",
     "@openuidev/react-ui": "workspace:^",
     "@openuidev/thesys": "0.3.2",
-    "@openuidev/thesys-server": "0.1.3",
+    "@openuidev/thesys-server": "0.1.4",
     "@phosphor-icons/react": "^2.1.10",
     "@radix-ui/react-dialog": "1.1.15",
     "@radix-ui/react-tooltip": "1.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,8 +85,8 @@ importers:
         specifier: 0.3.2
         version: 0.3.2(@openuidev/lang-core@packages+lang-core)(@openuidev/react-headless@packages+react-headless)(@openuidev/react-lang@packages+react-lang)(@openuidev/react-ui@packages+react-ui)(@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)(zustand@4.5.7(@types/react@19.2.17)(react@19.2.4))
       '@openuidev/thesys-server':
-        specifier: 0.1.3
-        version: 0.1.3
+        specifier: 0.1.4
+        version: 0.1.4
       '@phosphor-icons/react':
         specifier: ^2.1.10
         version: 2.1.10(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -2188,8 +2188,8 @@ packages:
     resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
     engines: {node: '>=14'}
 
-  '@openuidev/thesys-server@0.1.3':
-    resolution: {integrity: sha512-hIa1jvw4K7V97Z5drtk7pI0qmo2E/uLzm/buZzSTF/R9+JcKEdiD3JR9+KriIEdLNGa+1H3QsNNES+yQSQ3YwA==}
+  '@openuidev/thesys-server@0.1.4':
+    resolution: {integrity: sha512-kRP54tk5608IuTU0Rjwo4wE8oCpWIxLAphhBkNGHaeZd7hAXwLGmT/vcIZBIr8KQM3Riq/pczrOa/ksyXXtcvQ==}
 
   '@openuidev/thesys@0.3.2':
     resolution: {integrity: sha512-bVnVy2OcGawikt+R5QR4EBKtRvd0Y2PD9+Z94EClD5fSVtfi9VT9yztBp9a+r104SdB1GZuRuO3J/U+UALZgyg==}
@@ -11639,7 +11639,7 @@ snapshots:
   '@opentelemetry/semantic-conventions@1.43.0':
     optional: true
 
-  '@openuidev/thesys-server@0.1.3': {}
+  '@openuidev/thesys-server@0.1.4': {}
 
   '@openuidev/thesys@0.3.2(@openuidev/lang-core@packages+lang-core)(@openuidev/react-headless@packages+react-headless)(@openuidev/react-lang@packages+react-lang)(@openuidev/react-ui@packages+react-ui)(@radix-ui/react-tooltip@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(@tiptap/core@2.27.2(@tiptap/pm@2.27.2))(@tiptap/pm@2.27.2)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)(zustand@4.5.7(@types/react@19.2.17)(react@19.2.4))':
     dependencies:


### PR DESCRIPTION
Brings the docs site's pin of `@openuidev/thesys-server` level with the current npm release (0.1.3 → 0.1.4).

**What 0.1.4 brings for docs consumers:** the public export surface is unchanged from 0.1.3 — nothing added, nothing removed. The release annotates `generateSystemPrompt`, `createResponsesInstructions` and `ChatLibrary` as deprecated, pointing at `generateSystemPrompt` from `@openuidev/lang-core` with `{ cloud: true }`, and extracts an internal `JSONSchemaDef` type alias. The docs site imports only `artifactTool`, whose signature is unchanged, so no site code changes are needed here.

The lockfile entry is updated alongside the pin, since `docs/` sits inside the pnpm workspace and a pin bump on its own would fail CI's frozen install.

**Verified before opening:**
- `pnpm install --frozen-lockfile` green under pnpm 9.15.4 and 10.33.0, plus a full (non-`--lockfile-only`) frozen install under 10.33.0.
- Tarball integrity in the lockfile checked against the published artifact.
- Type surfaces diffed between the 0.1.3 and 0.1.4 tarballs; the export list is byte-identical.

The lockfile change is kept to the three entries the bump actually touches. Regenerating the whole file rewrites unrelated sections, so those were left alone.