### PR TITLE
fix(docs): enable PostHog remote config and 30% replay sampling

### DIFF
--- a/docs/lib/analytics.ts
+++ b/docs/lib/analytics.ts
@@ -7,10 +7,9 @@ export function loadPostHog(): Promise<PostHog> {
     posthog.init("phc_3OLW53x09ZTVZSV6BEpj5uycj3ooqR6KOemOjx04e3D", {
       api_host: "https://dgoeivjus9jfp.cloudfront.net",
       capture_pageview: "history_change",
-      advanced_disable_flags: true,
       disable_session_recording: false,
       session_recording: {
-        sampleRate: 0.1,
+        sampleRate: 0.3,
       },
       disable_surveys: true,
     });


### PR DESCRIPTION
PostHog loads on openui.com, but `advanced_disable_flags: true` prevents it from fetching the remote configuration required for session replay. Remove that override to restore remote configuration loading and increase replay sampling from 10% to 30%.

Validation: Prettier and `git diff --check` passed. ESLint could not run because the available local dependencies are missing `eslint-config-next`.

Deployment follow-up: the configured CloudFront endpoint currently returns `sessionRecording: false`. Enable session replay in the matching PostHog project and verify the proxy serves the updated configuration; this code change alone does not enable the server-side setting.
