### PR TITLE
feat(react-headless): expose token usage from openAIResponsesAdapter (#1078)

### DIFF
--- a/packages/react-headless/src/index.ts
+++ b/packages/react-headless/src/index.ts
@@ -108,6 +108,7 @@ export type {
   EveStreamEvent,
 } from "./stream/adapters/eve";
 export type { LangGraphAdapterOptions } from "./stream/adapters/langgraph";
+export type { OpenAIResponsesAdapterOptions } from "./stream/adapters/openai-responses";
 export type { LangGraphMessageFormat } from "./stream/formats/langgraph-message-format";
 export { identityMessageFormat } from "./types/messageFormat";
 export type { MessageFormat } from "./types/messageFormat";

--- a/packages/react-headless/src/stream/adapters/__tests__/openai-responses.test.ts
+++ b/packages/react-headless/src/stream/adapters/__tests__/openai-responses.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventType, type AGUIEvent } from "../../../types";
+import { openAIResponsesAdapter } from "../openai-responses";
+
+function sse(data: unknown): string {
+  return `data: ${JSON.stringify(data)}\n\n`;
+}
+
+function makeResponse(body: string): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(body));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+async function collect(iterable: AsyncIterable<AGUIEvent>): Promise<AGUIEvent[]> {
+  const events: AGUIEvent[] = [];
+  for await (const event of iterable) events.push(event);
+  return events;
+}
+
+describe("openAIResponsesAdapter", () => {
+  it("throws when response has no body", async () => {
+    const adapter = openAIResponsesAdapter();
+    const response = new Response(null);
+    await expect(async () => {
+      for await (const _ of adapter.parse(response)) {
+        /* drain */
+      }
+    }).rejects.toThrow("No response body");
+  });
+
+  it("yields text message events from output item and deltas", async () => {
+    const adapter = openAIResponsesAdapter();
+    const stream =
+      sse({
+        type: "response.output_item.added",
+        item: { id: "msg_1", type: "message", role: "assistant" },
+      }) +
+      sse({
+        type: "response.output_text.delta",
+        item_id: "msg_1",
+        delta: "Hello, world!",
+      }) +
+      sse({
+        type: "response.output_text.done",
+        item_id: "msg_1",
+      });
+
+    const events = await collect(adapter.parse(makeResponse(stream)));
+    expect(events).toEqual([
+      {
+        type: EventType.TEXT_MESSAGE_START,
+        messageId: "msg_1",
+        role: "assistant",
+      },
+      {
+        type: EventType.TEXT_MESSAGE_CONTENT,
+        messageId: "msg_1",
+        delta: "Hello, world!",
+      },
+      {
+        type: EventType.TEXT_MESSAGE_END,
+        messageId: "msg_1",
+      },
+    ]);
+  });
+
+  it("invokes onUsage callback with token usage details on response.completed", async () => {
+    const onUsage = vi.fn();
+    const adapter = openAIResponsesAdapter({ onUsage });
+
+    const usage = {
+      input_tokens: 42,
+      output_tokens: 18,
+      total_tokens: 60,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens_details: { reasoning_tokens: 0 },
+    };
+
+    const stream =
+      sse({
+        type: "response.output_item.added",
+        item: { id: "msg_1", type: "message", role: "assistant" },
+      }) +
+      sse({
+        type: "response.completed",
+        response: {
+          id: "resp_123",
+          usage,
+        },
+      });
+
+    await collect(adapter.parse(makeResponse(stream)));
+    expect(onUsage).toHaveBeenCalledTimes(1);
+    expect(onUsage).toHaveBeenCalledWith(usage);
+  });
+
+  it("does not invoke onUsage if response.completed does not contain usage", async () => {
+    const onUsage = vi.fn();
+    const adapter = openAIResponsesAdapter({ onUsage });
+
+    const stream = sse({
+      type: "response.completed",
+      response: {
+        id: "resp_123",
+      },
+    });
+
+    await collect(adapter.parse(makeResponse(stream)));
+    expect(onUsage).not.toHaveBeenCalled();
+  });
+
+  it("safely completes when onUsage is not provided", async () => {
+    const adapter = openAIResponsesAdapter();
+
+    const stream = sse({
+      type: "response.completed",
+      response: {
+        id: "resp_123",
+        usage: {
+          input_tokens: 10,
+          output_tokens: 20,
+          total_tokens: 30,
+        },
+      },
+    });
+
+    const events = await collect(adapter.parse(makeResponse(stream)));
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/react-headless/src/stream/adapters/openai-responses.ts
+++ b/packages/react-headless/src/stream/adapters/openai-responses.ts
@@ -1,6 +1,7 @@
 import type {
   ResponseFunctionToolCallOutputItem,
   ResponseStreamEvent,
+  ResponseUsage,
 } from "openai/resources/responses/responses";
 import { AGUIEvent, EventType, StreamProtocolAdapter } from "../../types";
 
@@ -8,7 +9,13 @@ import { AGUIEvent, EventType, StreamProtocolAdapter } from "../../types";
 const stringifyOutput = (output: unknown): string =>
   typeof output === "string" ? output : output != null ? JSON.stringify(output) : "";
 
-export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
+export interface OpenAIResponsesAdapterOptions {
+  onUsage?: (usage: ResponseUsage) => void;
+}
+
+export const openAIResponsesAdapter = (
+  options?: OpenAIResponsesAdapterOptions,
+): StreamProtocolAdapter => ({
   async *parse(response: Response): AsyncIterable<AGUIEvent> {
     const reader = response.body?.getReader();
     if (!reader) throw new Error("No response body");
@@ -246,6 +253,13 @@ export const openAIResponsesAdapter = (): StreamProtocolAdapter => ({
                 code: event.response?.error?.code ?? undefined,
               };
               break;
+
+            case "response.completed": {
+              if (event.response?.usage && options?.onUsage) {
+                options.onUsage(event.response.usage);
+              }
+              break;
+            }
 
             // Intentionally unhandled — these are lifecycle/metadata events:
             // response.created, response.in_progress, response.completed,


### PR DESCRIPTION
### Summary

Fixes #1078

Exposes an optional `onUsage` callback in `openAIResponsesAdapter` so consuming applications can read token usage (prompt, completion, total tokens, and breakdown details) from the OpenAI Responses stream without having to maintain a custom adapter.

### Changes

- Added `OpenAIResponsesAdapterOptions` interface with `onUsage?: (usage: ResponseUsage) => void`.
- Updated `openAIResponsesAdapter(options?: OpenAIResponsesAdapterOptions)` to accept options.
- Added a handler for `response.completed` event: when `event.response?.usage` is available, invokes `options.onUsage(event.response.usage)`.
- Re-exported `OpenAIResponsesAdapterOptions` from `@openuidev/react-headless`.
- Added unit tests in `openai-responses.test.ts` verifying:
  - Output item and text deltas stream normally.
  - `onUsage` is invoked with the parsed `ResponseUsage` on `response.completed`.
  - Adapter safely handles missing usage or omitted `options`.

### Testing

- Ran `pnpm --filter @openuidev/react-headless test` — all 20 test files (190 tests) passed.
- Ran ESLint and Prettier checks.