### PR TITLE
ci: fix release PR creation and CLI e2e pnpm matrix

### DIFF
--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -168,6 +168,11 @@ jobs:
 
       - name: Verify package manager version
         shell: bash
+        # Outside the repo checkout: inside it, pnpm >=10 self-switches to the
+        # root packageManager version (pnpm@10.33.0) and would report that
+        # instead of the matrix-installed version. The e2e steps below all run
+        # under runner.temp too, so this verifies what they will actually use.
+        working-directory: ${{ runner.temp }}
         env:
           PACKAGE_MANAGER: ${{ matrix.package-manager }}
           EXPECTED_MAJOR: ${{ matrix.package-manager-version }}

--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -160,6 +160,11 @@ jobs:
         if: matrix.package-manager == 'pnpm'
         with:
           version: ${{ matrix.package-manager-version }}
+          # The matrix version must win here; reading the repo root's
+          # packageManager field (pnpm@10.33.0) alongside an explicit version
+          # is a hard error in action-setup v6, so point it at a manifest
+          # without that field.
+          package_json_file: packages/openui-cli/package.json
 
       - name: Verify package manager version
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,18 +7,31 @@ on:
 concurrency: release
 
 permissions:
-  contents: write # push the changeset-release branch, create tags + GitHub Releases
-  pull-requests: write # maintain the Version Packages PR
+  contents: read # checkout only; push/PR/release rights come from the app token
   id-token: write # npm OIDC trusted publishing
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # Branch pushes, the Version Packages PR, tags, and GitHub Releases are
+      # made with a GitHub App token instead of GITHUB_TOKEN: GITHUB_TOKEN is
+      # not permitted to create PRs in this org, and app-made pushes and PRs
+      # trigger workflows, so the Version PR gets normal CI. The app needs
+      # Contents + Pull requests read/write on this repo.
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.THESYS_PR_CREATOR_APP_ID }}
+          private-key: ${{ secrets.THESYS_PR_CREATOR_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           # Full history: @changesets/changelog-github links commits/PRs
           fetch-depth: 0
+          # Persist the app token so the action's branch pushes use the app identity
+          token: ${{ steps.app-token.outputs.token }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v4
         with:
@@ -47,11 +60,11 @@ jobs:
           create-github-releases: true
           pr-title: "chore: version packages"
           commit-message: "chore: version packages"
+          # PR creation, tags, and GitHub Releases act as the app
+          github-token: ${{ steps.app-token.outputs.token }}
         env:
-          # GITHUB_TOKEN-pushed branches trigger no workflows: the Version
-          # Packages PR runs zero CI. Swap in a PAT/GitHub App token here if
-          # CI on that PR (or required status checks on main) is needed.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # For @changesets/changelog-github's PR/commit lookups in version-script
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Same build-memory headroom as build-js.yml
           NODE_OPTIONS: --max-old-space-size=6144
         # Note: npm provenance is generated automatically with trusted


### PR DESCRIPTION
- release.yml: create the Version Packages PR with a token minted from the THESYS_PR_CREATOR GitHub App (vars.THESYS_PR_CREATOR_APP_ID + secrets.THESYS_PR_CREATOR_PRIVATE_KEY). GITHUB_TOKEN is not permitted to create PRs in this org, so every Release run has been failing at PR creation; app-made pushes and PRs also trigger workflows, giving the Version PR normal CI. Token goes to the action's github-token input (v2) and to env GITHUB_TOKEN for @changesets/changelog-github lookups; workflow permissions drop to contents:read + id-token:write.
- cli-e2e.yml: the pnpm matrix step's explicit version collides with the root packageManager field (action-setup v6 hard-errors on the mismatch); point package_json_file at packages/openui-cli/package.json so the matrix version stays authoritative for template testing.

Requires the app var/secret to be configured on the repo before the next Release run can succeed.
