### PR TITLE
fix: release devtools as minor, not patch

### DIFF
--- a/.changeset/bounded-internal-peer-ranges.md
+++ b/.changeset/bounded-internal-peer-ranges.md
@@ -1,6 +1,5 @@
 ---
 "@openuidev/assistant-ui": patch
-"@openuidev/devtools": patch
 ---
 
 Internal `@openuidev/*` peer dependencies now declare bounded

--- a/.changeset/devtools-bounded-peer-ranges.md
+++ b/.changeset/devtools-bounded-peer-ranges.md
@@ -1,0 +1,10 @@
+---
+"@openuidev/devtools": minor
+---
+
+Internal peer dependencies now declare bounded tested-compatibility ranges:
+`@openuidev/react-lang` requires `">=0.3.0 <0.4.0"`. Minor (breaking) rather
+than patch on purpose: react-lang 0.2.x depends on devtools with `^0.1.0`, so
+a 0.1.x release would be pulled into existing react-lang 0.2.x installs and
+fail them with an unsatisfiable peer. Bumping to 0.2.0 keeps old react-lang
+paired with old devtools; react-lang >=0.3.0 picks up the new line.

--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -168,6 +168,11 @@ jobs:
 
       - name: Verify package manager version
         shell: bash
+        # Outside the repo checkout: inside it, pnpm >=10 self-switches to the
+        # root packageManager version (pnpm@10.33.0) and would report that
+        # instead of the matrix-installed version. The e2e steps below all run
+        # under runner.temp too, so this verifies what they will actually use.
+        working-directory: ${{ runner.temp }}
         env:
           PACKAGE_MANAGER: ${{ matrix.package-manager }}
           EXPECTED_MAJOR: ${{ matrix.package-manager-version }}

--- a/.github/workflows/cli-e2e.yml
+++ b/.github/workflows/cli-e2e.yml
@@ -160,6 +160,11 @@ jobs:
         if: matrix.package-manager == 'pnpm'
         with:
           version: ${{ matrix.package-manager-version }}
+          # The matrix version must win here; reading the repo root's
+          # packageManager field (pnpm@10.33.0) alongside an explicit version
+          # is a hard error in action-setup v6, so point it at a manifest
+          # without that field.
+          package_json_file: packages/openui-cli/package.json
 
       - name: Verify package manager version
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,18 +7,31 @@ on:
 concurrency: release
 
 permissions:
-  contents: write # push the changeset-release branch, create tags + GitHub Releases
-  pull-requests: write # maintain the Version Packages PR
+  contents: read # checkout only; push/PR/release rights come from the app token
   id-token: write # npm OIDC trusted publishing
 
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # Branch pushes, the Version Packages PR, tags, and GitHub Releases are
+      # made with a GitHub App token instead of GITHUB_TOKEN: GITHUB_TOKEN is
+      # not permitted to create PRs in this org, and app-made pushes and PRs
+      # trigger workflows, so the Version PR gets normal CI. The app needs
+      # Contents + Pull requests read/write on this repo.
+      - name: Mint app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.THESYS_PR_CREATOR_APP_ID }}
+          private-key: ${{ secrets.THESYS_PR_CREATOR_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           # Full history: @changesets/changelog-github links commits/PRs
           fetch-depth: 0
+          # Persist the app token so the action's branch pushes use the app identity
+          token: ${{ steps.app-token.outputs.token }}
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v4
         with:
@@ -47,11 +60,11 @@ jobs:
           create-github-releases: true
           pr-title: "chore: version packages"
           commit-message: "chore: version packages"
+          # PR creation, tags, and GitHub Releases act as the app
+          github-token: ${{ steps.app-token.outputs.token }}
         env:
-          # GITHUB_TOKEN-pushed branches trigger no workflows: the Version
-          # Packages PR runs zero CI. Swap in a PAT/GitHub App token here if
-          # CI on that PR (or required status checks on main) is needed.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # For @changesets/changelog-github's PR/commit lookups in version-script
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           # Same build-memory headroom as build-js.yml
           NODE_OPTIONS: --max-old-space-size=6144
         # Note: npm provenance is generated automatically with trusted


### PR DESCRIPTION
react-lang 0.2.x depends on devtools ^0.1.0, so a devtools 0.1.x release carrying the new peer requirement (react-lang >=0.3.0) would be pulled into existing react-lang 0.2.x installs and break them with an unsatisfiable peer at install time. Releasing 0.2.0 instead escapes ^0.1.0: old react-lang keeps resolving old devtools, and only react-lang >=0.3.0 (released in the same train, depending on devtools ^0.2.0) picks up the new line. Same reasoning as react-email's minor in the original release-automation PR.