### PR TITLE
fix: release devtools as minor, not patch

### DIFF
--- a/.changeset/bounded-internal-peer-ranges.md
+++ b/.changeset/bounded-internal-peer-ranges.md
@@ -1,6 +1,5 @@
 ---
 "@openuidev/assistant-ui": patch
-"@openuidev/devtools": patch
 ---
 
 Internal `@openuidev/*` peer dependencies now declare bounded

--- a/.changeset/devtools-bounded-peer-ranges.md
+++ b/.changeset/devtools-bounded-peer-ranges.md
@@ -1,0 +1,10 @@
+---
+"@openuidev/devtools": minor
+---
+
+Internal peer dependencies now declare bounded tested-compatibility ranges:
+`@openuidev/react-lang` requires `">=0.3.0 <0.4.0"`. Minor (breaking) rather
+than patch on purpose: react-lang 0.2.x depends on devtools with `^0.1.0`, so
+a 0.1.x release would be pulled into existing react-lang 0.2.x installs and
+fail them with an unsatisfiable peer. Bumping to 0.2.0 keeps old react-lang
+paired with old devtools; react-lang >=0.3.0 picks up the new line.


### PR DESCRIPTION
react-lang 0.2.x depends on devtools ^0.1.0, so a devtools 0.1.x release carrying the new peer requirement (react-lang >=0.3.0) would be pulled into existing react-lang 0.2.x installs and break them with an unsatisfiable peer at install time. Releasing 0.2.0 instead escapes ^0.1.0: old react-lang keeps resolving old devtools, and only react-lang >=0.3.0 (released in the same train, depending on devtools ^0.2.0) picks up the new line. Same reasoning as react-email's minor in the original release-automation PR.