### PR TITLE
blog(oui-1): weights are Apache 2.0

### DIFF
--- a/docs/content/blog/oui-1.mdx
+++ b/docs/content/blog/oui-1.mdx
@@ -6,7 +6,7 @@ author: "Thesys Engineering Team"
 featured: true
 ---
 
-OUI-1 is a finetuned [DiffusionGemma](https://blog.google/innovation-and-ai/technology/developers-tools/diffusion-gemma-faster-text-generation/) model that writes user interfaces in [openui-lang](/docs/openui-lang). It is 26BA4B model that can run on consumer grade GPU (RTX 5090, at FP8), and the weights are on [Hugging Face](https://huggingface.co/thesysdev/OUI-1) under the Gemma Terms of Use.
+OUI-1 is a finetuned [DiffusionGemma](https://blog.google/innovation-and-ai/technology/developers-tools/diffusion-gemma-faster-text-generation/) model that writes user interfaces in [openui-lang](/docs/openui-lang). It is 26BA4B model that can run on consumer grade GPU (RTX 5090, at FP8), and the weights are on [Hugging Face](https://huggingface.co/thesysdev/OUI-1) under Apache 2.0, the same license as the base model.
 
 <iframe
   src="/blog/dg-reveal.html"


### PR DESCRIPTION
The OUI-1 post says the weights are published under the Gemma Terms of Use. That is the Gemma 3 licence. The base model, google/diffusiongemma-26B-A4B-it, is Apache 2.0 like the rest of the Gemma 4 family (its card metadata is `license: apache-2.0`, linking https://ai.google.dev/gemma/docs/gemma_4_license), so OUI-1 is Apache 2.0 as well.

One-line change in `docs/content/blog/oui-1.mdx`. The Hugging Face model card and adapter card (thesysdev/OUI-1) were already updated to `license: apache-2.0`.